### PR TITLE
Vnext

### DIFF
--- a/Cecilifier.Core.Tests/Framework/AssemblyDiff/AssemblyComparer.cs
+++ b/Cecilifier.Core.Tests/Framework/AssemblyDiff/AssemblyComparer.cs
@@ -12,7 +12,7 @@ namespace Cecilifier.Core.Tests.Framework.AssemblyDiff
     internal class AssemblyComparer
     {
         private static readonly Dictionary<Code, Func<Instruction, Instruction, (bool, int)>> _instructionValidator =
-            new Dictionary<Code, Func<Instruction, Instruction, (bool, int)>>
+            new()
             {
                 {Code.Ret, OperandObliviousValidator},
                 {Code.Nop, OperandObliviousValidator},

--- a/Cecilifier.Core.Tests/TestResources/Integration/Expressions/ArrayLength.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Expressions/ArrayLength.cs.txt
@@ -1,0 +1,14 @@
+﻿class ArrayLength<C>
+{
+    int M1(int []a) => a.Length;
+    int M2<T>(T []a) => a.Length;
+    int M3<C>(C []a, int i) => a.Length + i;
+    
+    long M4(int []a) => a.Length;
+    long M5<T>(T []a) => a.Length;
+    long M6<C>(C []a, int i) => a.Length + i;
+    
+    long M7(int []a) => a.LongLength;
+    long M8<T>(T []a) => a.LongLength;
+    long M9<C>(C []a, int i) => a.LongLength + i;
+}

--- a/Cecilifier.Core.Tests/TestResources/Integration/Expressions/ExpressionBodiedMembers.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Expressions/ExpressionBodiedMembers.cs.txt
@@ -19,16 +19,11 @@ class ExpressionBodiedMembers
 	
 	T Generic<T>(T p) => p; 
 	
-	/*
-	not supported
 	public int Prop2 => 42;
-	*/
 	
-	/*
 	public string this[int i]
 	{
 	    get => i.ToString();
-	    set => Console.WriteLine(i.ToString() + ":" + value);
+	    set => Console.WriteLine(i);
 	}
-	*/
 } 

--- a/Cecilifier.Core.Tests/TestResources/Integration/Members/ForwardReferences.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Members/ForwardReferences.cs.txt
@@ -1,12 +1,14 @@
-﻿class NoParameters
+﻿class ForwardReferences
 {
-	public void Foo() 
-	{
-		Bar();
-	}
-
-	private void Bar()
-	{
-		Foo();
-	}
+	void Foo() => Bar();
+	void Bar() => Foo();
+	
+	int FieldRef1() => field; 
+	int FieldRef2() => field;
+	
+	int PropertyRef1() => Property;
+	int PropertyRef2() => Property;
+	
+	int field = 32;
+	int Property { get => 10; }
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/ValueTypes/AsTargetOfCall/ValueTypeReturnAsTargetOfCall.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/ValueTypes/AsTargetOfCall/ValueTypeReturnAsTargetOfCall.cs.txt
@@ -1,5 +1,14 @@
 ﻿class ValueTypeReturnAsTargetOfCall
 {
+    int field = 42;
+
+	int PropertyValue
+	{
+		get { return 10; }
+	}
+	
+	string OnProperty() => PropertyValue.ToString();
+
 	void OnConst()
 	{
 		42.ToString();
@@ -10,56 +19,41 @@
 		MethodValue().ToString();
 	}
 
-	void OnProperty()
-	{
-    	PropertyValue.ToString();
-	}
-
-	void OnField()
-	{
-    	field.ToString();
-	}
-
 	void OnParameter(int param)
 	{
     	param.ToString();
 	}
-
-	void OnDelegate(System.Func<int> del)
-	{
-        del().ToString();
-	}
-
-	void OnCast(object o)
-	{
-        ((int) o).ToString();
-	}
-
-    void OnChainedInvocations()
-    {
-    	var s = 42.GetHashCode().ToString();
-    }
 
 	void OnLocalVariable()
 	{
         int local = 42;
         local.ToString();
 	}
-
-	int PropertyValue
+   
+	void OnDelegate(System.Func<int> del)
 	{
-		get { return 10; }
+        del().ToString();
 	}
 
+	void OnField()
+	{
+    	field.ToString();
+	}
+		
 	int MethodValue() 
 	{
 		return 42;
 	}
 
-	public ValueTypeReturnAsTargetOfCall()
+    string OnChainedInvocations() 
+    {
+       return 42.Equals(null).ToString();
+    }
+    
+/*
+	void OnCast(object o)
 	{
-		field = 42;
+        ((int) o).ToString();
 	}
-
-    private int field = 42;
+*/
 }

--- a/Cecilifier.Core.Tests/Tests/Integration/ExpressionTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/ExpressionTestCase.cs
@@ -132,6 +132,12 @@ namespace Cecilifier.Core.Tests.Integration
         }
 
         [Test]
+        public void TestArrayLength()
+        {
+            AssertResourceTest($@"Expressions/ArrayLength");
+        }
+
+        [Test]
         public void TestRangeExpression()
         {
             AssertResourceTest(@"Expressions/RangeExpression");

--- a/Cecilifier.Core.Tests/Tests/Integration/ValueTypesTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/ValueTypesTests.cs
@@ -5,7 +5,7 @@ namespace Cecilifier.Core.Tests.Integration
     [TestFixture]
     public class ValueTypesTests : IntegrationResourceBasedTest
     {
-        //[TestCase("ValueTypeReturnAsTargetOfCall")]
+        [TestCase("ValueTypeReturnAsTargetOfCall")]
         [TestCase("MultipleLiteralAsTargetOfCall")]
         [TestCase("SingleLiteralAsTargetOfCall")]
         [TestCase("ValueTypeReturnAsTargetOfCallInsideBaseConstructorInvocation")]

--- a/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
@@ -19,6 +19,7 @@ namespace Cecilifier.Core.AST
 
         public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
         {
+            Context.WriteComment($"Enum: {node.Identifier}");
             _memberCollector = new EnumMemberValueCollector();
             node.Accept(_memberCollector);
 

--- a/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
@@ -28,14 +28,14 @@ namespace Cecilifier.Core.AST
             var typeDef = CecilDefinitionsFactory.Type(Context, enumType, node.Identifier.ValueText, attrs + " | TypeAttributes.Sealed", Context.TypeResolver.Resolve("System.Enum"), false, Array.Empty<string>());
             AddCecilExpressions(typeDef);
 
-            using (Context.DefinitionVariables.WithCurrent(node.Parent.IsKind(SyntaxKind.CompilationUnit) ? "" : node.Parent.ResolveDeclaringType<TypeDeclarationSyntax>().Identifier.ValueText, node.Identifier.ValueText, MemberKind.Type,
-                enumType))
+            var parentName = node.Parent.IsKind(SyntaxKind.CompilationUnit) ? "" : node.Parent.ResolveDeclaringType<TypeDeclarationSyntax>().Identifier.ValueText;
+            using (Context.DefinitionVariables.WithCurrent(parentName, node.Identifier.ValueText, MemberKind.Type,enumType))
             {
                 //.class private auto ansi MyEnum
                 //TODO: introduce TypeSystem.CoreLib.Enum/Action/etc...
 
                 var fieldVar = MethodExtensions.LocalVariableNameFor("valueField", node.Identifier.ValueText);
-                var valueFieldExp = CecilDefinitionsFactory.Field(enumType, fieldVar, "value__", "assembly.MainModule.TypeSystem.Int32",
+                var valueFieldExp = CecilDefinitionsFactory.Field(enumType, fieldVar, "value__", Context.TypeResolver.ResolvePredefinedType(GetSpecialType(SpecialType.System_Int32)),
                     "FieldAttributes.SpecialName | FieldAttributes.RTSpecialName | FieldAttributes.Public");
                 AddCecilExpressions(valueFieldExp);
 

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Misc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -49,7 +50,7 @@ namespace Cecilifier.Core.AST
                 }
                 else
                 {
-                    WriteCecilExpression(ctx, @"{0}.Append({0}.Create({1}));", ilVar, OpCodes.Add.ConstantName());
+                    WriteCecilExpression(ctx, "{0}.Append({0}.Create({1}));", ilVar, OpCodes.Add.ConstantName());
                 }
             };
 

--- a/Cecilifier.Core/AST/FieldDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/FieldDeclarationVisitor.cs
@@ -8,7 +8,6 @@ using Cecilifier.Core.Misc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
 
 namespace Cecilifier.Core.AST
 {
@@ -48,6 +47,11 @@ namespace Cecilifier.Core.AST
 
             foreach (var field in variableDeclarationSyntax.Variables)
             {
+                // skip field already processed due to forward references.
+                var fieldDeclarationVariable = Context.DefinitionVariables.GetVariable(field.Identifier.Text, MemberKind.Field, declaringType.Identifier.Text);
+                if (fieldDeclarationVariable.IsValid)
+                    continue;
+
                 var fieldVar = MethodExtensions.LocalVariableNameFor("fld", declaringType.Identifier.ValueText, field.Identifier.ValueText.CamelCase());
                 fieldDefVars.Add(fieldVar);
                 

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
@@ -115,6 +115,8 @@ namespace Cecilifier.Core.AST
 
         private string HandleTypeDeclaration(TypeDeclarationSyntax node, string baseType)
         {
+            Context.WriteComment($"{node.Kind()} : {node.Identifier}");
+            
             var varName = LocalVariableNameForId(NextLocalVariableTypeId());
             var isStructWithNoFields = node.Kind() == SyntaxKind.StructDeclaration && node.Members.Count == 0;
             var typeDefinitionExp = CecilDefinitionsFactory.Type(

--- a/Cecilifier.Core/Extensions/MethodExtensions.cs
+++ b/Cecilifier.Core/Extensions/MethodExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Cecilifier.Core.AST;
+using Cecilifier.Core.Misc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -65,7 +66,7 @@ namespace Cecilifier.Core.Extensions
             {
                 var paramTypes = method.ConstructedFrom.Parameters.AsStringNewArrayExpression();
                 var typeArguments = method.TypeArguments.AsStringNewArrayExpression();
-                return $"assembly.MainModule.Import(TypeHelpers.ResolveGenericMethod(\"{method.ContainingAssembly.Name}\", \"{declaringTypeName}\", \"{method.Name}\",{method.Modifiers()}, {typeArguments}, {paramTypes}))";
+                return Utils.ImportFromMainModule($"TypeHelpers.ResolveGenericMethod(\"{method.ContainingAssembly.Name}\", \"{declaringTypeName}\", \"{method.Name}\",{method.Modifiers()}, {typeArguments}, {paramTypes})");
             }
 
             if (!method.ContainingType.IsValueType && !method.ContainingType.IsGenericType)

--- a/Cecilifier.Core/Extensions/SyntaxNodeExtensions.cs
+++ b/Cecilifier.Core/Extensions/SyntaxNodeExtensions.cs
@@ -57,5 +57,7 @@ namespace Cecilifier.Core.Extensions
 
             return s.ToString();
         }
+        
+        public static string SourceDetails(this SyntaxNode node) => $"{node} ({node.SyntaxTree.GetMappedLineSpan(node.Span).Span})";
     }
 }

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -153,7 +153,7 @@ namespace Cecilifier.Core.Misc
             return exps;
         }
 
-        public static string Parameter(string name, RefKind byRef, bool isParams, string resolvedType)
+        public static string Parameter(string name, RefKind byRef, string resolvedType)
         {
             if (RefKind.None != byRef)
             {
@@ -167,7 +167,7 @@ namespace Cecilifier.Core.Misc
         {
             var exps = new List<string>();
 
-            exps.Add($"var {paramVar} = {Parameter(name, byRef, isParams, resolvedType)};");
+            exps.Add($"var {paramVar} = {Parameter(name, byRef, resolvedType)};");
             AddExtraAttributes(exps, paramVar, byRef);
 
             if (isParams)
@@ -196,8 +196,7 @@ namespace Cecilifier.Core.Misc
         {
             return Parameter(
                 paramSymbol.Name, 
-                paramSymbol.RefKind, 
-                isParams: paramSymbol.IsParams,
+                paramSymbol.RefKind,
                 resolvedType);
         }
 
@@ -371,10 +370,9 @@ namespace Cecilifier.Core.Misc
 
         private static string FunctionPointerTypeBasedCecilType(ITypeResolver resolver, IFunctionPointerTypeSymbol functionPointer, Func<string, string, string, string> factory)
         {
-            var hasThis = $"HasThis = false";
-            var parameters = $"Parameters={{ {string.Join(',', functionPointer.Signature.Parameters.Select(p => CecilDefinitionsFactory.Parameter(p, resolver.Resolve(p.Type))))} }}";
+            var parameters = $"Parameters={{ {string.Join(',', functionPointer.Signature.Parameters.Select(p => Parameter(p, resolver.Resolve(p.Type))))} }}";
             var returnType = resolver.Resolve(functionPointer.Signature.ReturnType);
-            return factory(hasThis, parameters, returnType);
+            return factory("HasThis = false", parameters, returnType);
         }
     }
 }

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -153,7 +153,7 @@ namespace Cecilifier.Core.Misc
             return exps;
         }
 
-        public static string Parameter(string name, RefKind byRef, string resolvedType)
+        private static string Parameter(string name, RefKind byRef, string resolvedType)
         {
             if (RefKind.None != byRef)
             {

--- a/Cecilifier.Core/Misc/Utils.cs
+++ b/Cecilifier.Core/Misc/Utils.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Cecilifier.Core.AST;
 using Cecilifier.Core.Extensions;
 using Microsoft.CodeAnalysis;
@@ -6,11 +7,8 @@ namespace Cecilifier.Core.Misc
 {
     internal struct Utils
     {
-        public static string ImportFromMainModule(string expression)
-        {
-            return $"assembly.MainModule.ImportReference({expression})";
-        }
-        
+        public static string ImportFromMainModule(string expression) => $"assembly.MainModule.ImportReference({expression})";
+
         public static string MakeGenericTypeIfAppropriate(IVisitorContext context, ISymbol memberSymbol, string backingFieldVar, string memberDeclaringTypeVar)
         {
             if (!(memberSymbol.ContainingSymbol is INamedTypeSymbol ts) || !ts.IsGenericType || !memberSymbol.IsDefinedInCurrentType(context))
@@ -24,6 +22,12 @@ namespace Cecilifier.Core.Misc
             context.WriteNewLine();
 
             return $"{genTypeVar}_";
+        }
+        
+        public static void EnsureNotNull([DoesNotReturnIf(true)] bool isNull, string msg)
+        {
+            if (isNull)
+                throw new System.NotSupportedException(msg);
         }
     }
 }

--- a/Cecilifier.Web/Startup.cs
+++ b/Cecilifier.Web/Startup.cs
@@ -240,8 +240,7 @@ namespace Cecilifier.Web
             ]
         }}";
             
-            SendJsonMessageToChat(toSend);
-            
+            SendJsonMessageToChat(toSend);            
         }
 
         private void SendSyntaxErrorToChat(SyntaxErrorException syntaxErrorException, byte[] code, int length)
@@ -266,6 +265,11 @@ namespace Cecilifier.Web
         private void SendJsonMessageToChat(string jsonMessage)
         {
             var discordChannelUrl = Configuration["DiscordChannelUrl"];
+            if (string.IsNullOrWhiteSpace(discordChannelUrl))
+            {
+                Console.WriteLine("DiscordChannelUrl not specified in configuration file.");
+                return;
+            }            
             
             var discordPostRequest = WebRequest.Create(discordChannelUrl);
             discordPostRequest.ContentType = "application/json";


### PR DESCRIPTION
- do not fail if DiscordChannelUrl has not been set in the configuration file
- comment type declarations in the generated code
- fixes handling of getter only expression-bodied property (issue #67)
- Fixes handling of forwarded  field/property references
- fixes handling of calls on value types
- fixes Array.Length/LongLength handling
- some *nullability* code cleanup
