### PR TITLE
Fix FileNotFoundException appsettings.Production.json

### DIFF
--- a/Cecilifier.Web/Program.cs
+++ b/Cecilifier.Web/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -11,7 +11,12 @@ namespace Cecilifier.Web
         public static void Main(string[] args)
         {
             var configurationBuilder = new ConfigurationBuilder();
-            var config = configurationBuilder.AddJsonFile($"appsettings.Production.json", optional: false).Build();
+            var appsettingsJsonFileName = "appsettings.json";
+            if (File.Exists("appsettings.Production.json"))
+            {
+                appsettingsJsonFileName = "appsettings.Production.json";
+            }
+            var config = configurationBuilder.AddJsonFile(appsettingsJsonFileName, optional: false).Build();
 
             var host = new HostBuilder()
                 .UseContentRoot(Directory.GetCurrentDirectory())


### PR DESCRIPTION
Fixed FileNotFoundException of 'appsettings.Production.json' occurred after `dotnet run` Cecilifier.Web:

> Unhandled exception. System.IO.FileNotFoundException: The configuration file 'appsettings.Production.json' was not found and is not optional. The expected physical path was 'Z:\cecilifier\Cecilifier.Web\bin\Debug\net6.0\appsettings.Production.json'

Not sure if this is a proper fix but it works for me. Tested locally.