### PR TITLE
Promoting stating to production - 06-Oct-2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 
 - bumped cecilifier version to 1.60.0
+- fixed NRE when handling explicit delegate instantiation (#190)
+- fixed TypeAttributes for static top level/inner types (#191)
+- change code to copy .runtimeconfig.json file when running the cecilified code (#189)
+- do not load implicit 'this' for static property access (#187)
 
 ## 15/Sept/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 ## [Unreleased]
 
+- bumped cecilifier version to 1.60.0
+
+## 15/Sept/2022
+
+## Changed
+
 - bumped cecilifier version to 1.50.0
+- updated testing section of README.md
+
+## Added
+
+- support for covariant properties (#179)
+- support for covariant return methods (#179)
+- support for using statement (#177)
+- support for modulus operator (%)
+
+## Fixed
+
+- static automatic properties being handled as instance ones (#183)
+- forwarded field references generating invalid code (#182)
+- forwarded attribute usage (#180)
+- handling of attributes in type parameters (#181)
 
 ## 15/May/2022
 

--- a/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
@@ -79,4 +79,16 @@ public class DelegateTests : CecilifierUnitTestBase
         var cecilifiedCode = result.GeneratedCode.ReadToEnd();
         Assert.That(cecilifiedCode, Contains.Substring("WARNING: Converting static method (M) to delegate in a type other than the one defining it may generate incorrect code. Access type: Bar, Method type: Foo"));
     }
+
+    [TestCase(@"class C { float F() => 42.0F; void M() { var r = new System.Func<float>(F); } }", TestName = "Explicit")]
+    [TestCase(@"class C { float F() => 42.0F; void M(System.Func<float> r) { M(F); } }", TestName = "Through method group conversion")]
+    public void DelegateInstantiation(string source)
+    {
+        var result = RunCecilifier(source);
+        Assert.That(
+            result.GeneratedCode.ReadToEnd(), 
+            Does.Match(@"(il_M_4\.Emit\(OpCodes\.)Ldarg_0\);\s+" +
+                       @"\1Ldftn, m_F_1\);\s+" +
+                       @"\1Newobj, .+System.Func`1.+System\.Single.+System\.Object.+System\.IntPtr.+\);\s+"));
+    }    
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
@@ -94,4 +94,17 @@ class Bar {{ public void M() {{ }} }}
         foreach(var expectedExpression in expectedExpressions)
             Assert.That(cecilifiedCode, Contains.Substring(expectedExpression));
     }
+
+    // Issue #187
+    [TestCase("class Foo { static int X { get; } static int M() => X; }", "m_get_2", TestName = "Property")]
+    [TestCase("class Foo { static event System.Action E; static void M() => E += M; }", "m_add_2", TestName = "Event")]
+    public void StaticMembers(string source, string expectedMethodCall)
+    {
+        var result = RunCecilifier(source);
+        var cecilifiedCode = result.GeneratedCode.ReadToEnd();
+        Assert.That(cecilifiedCode, Does.Not.Match(
+            @"(il_M_\d+\.Emit\(OpCodes\.)Ldarg_0\);\s+" +
+			$@"\1Call, {expectedMethodCall}\);\s+"), 
+            "ldarg.0 is not expected");
+    }
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class TypeTests : CecilifierUnitTestBase
+{
+    [TestCase("static class T {}", TestName = "Top Level")]
+    [TestCase("class T { public static class Inner { } }", TestName = "Inner")]
+    [TestCase("static class T { public static class Inner { } }", TestName = "Outer and Inner")]
+    public void StaticTypes(string code)
+    {
+        var result = RunCecilifier(code);
+        var cecilifiedCode = result.GeneratedCode.ReadToEnd();
+        
+        Assert.That(cecilifiedCode, Does.Not.Contain("TypeAttributes.Static"));
+        Assert.That(cecilifiedCode, Does.Contain("TypeAttributes.Abstract"));
+        Assert.That(cecilifiedCode, Does.Contain("TypeAttributes.Sealed"));
+    }
+}

--- a/Cecilifier.Core/AST/ConstructorDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/ConstructorDeclarationVisitor.cs
@@ -34,7 +34,7 @@ namespace Cecilifier.Core.AST
         private void HandleStaticConstructor(ConstructorDeclarationSyntax node)
         {
             var variableName = Context.Naming.Constructor(node.ResolveDeclaringType<BaseTypeDeclarationSyntax>(), true);
-            ProcessMethodDeclaration(node, variableName, Constants.CommonCecilConstants.StaticConstructorName, $".{Constants.CommonCecilConstants.StaticConstructorName}", false, ctorVar =>
+            ProcessMethodDeclaration(node, variableName, Constants.Cecil.StaticConstructorName, $".{Constants.Cecil.StaticConstructorName}", false, ctorVar =>
             {
                 var declaringType = node.Parent.ResolveDeclaringType<TypeDeclarationSyntax>();
                 ProcessFieldInitialization(declaringType, ilVar, true);
@@ -79,7 +79,7 @@ namespace Cecilifier.Core.AST
 
         protected override string GetSpecificModifiers()
         {
-            return string.Empty.AppendModifier(Constants.CommonCecilConstants.CtorAttributes);
+            return string.Empty.AppendModifier(Constants.Cecil.CtorAttributes);
         }
 
         internal void DefaultCtorInjector(string typeDefVar, ClassDeclarationSyntax declaringClass, bool isStatic)
@@ -123,7 +123,7 @@ namespace Cecilifier.Core.AST
             {
                 ctorLocalVar = found.VariableName;
                 
-                AddCecilExpression($"{ctorLocalVar}.Attributes = {ctorAccessibility} | MethodAttributes.HideBySig | {Constants.CommonCecilConstants.CtorAttributes};");
+                AddCecilExpression($"{ctorLocalVar}.Attributes = {ctorAccessibility} | MethodAttributes.HideBySig | {Constants.Cecil.CtorAttributes};");
                 AddCecilExpression($"{ctorLocalVar}.HasThis = !{ctorLocalVar}.IsStatic;", ctorLocalVar);
                 return ctorLocalVar;
             }

--- a/Cecilifier.Core/AST/ConversionOperatorDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/ConversionOperatorDeclarationVisitor.cs
@@ -42,6 +42,6 @@ namespace Cecilifier.Core.AST
                 _ => base.VisitOperatorDeclaration(node));
         }
 
-        protected override string GetSpecificModifiers() => Constants.CommonCecilConstants.MethodAttributesSpecialName;
+        protected override string GetSpecificModifiers() => Constants.Cecil.MethodAttributesSpecialName;
     }
 }

--- a/Cecilifier.Core/AST/EventDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EventDeclarationVisitor.cs
@@ -130,7 +130,7 @@ namespace Cecilifier.Core.AST
         private static string AccessModifiersForEventAccessors(MemberDeclarationSyntax node, bool isInterfaceDef)
         {
             var accessorModifiers = isInterfaceDef 
-                ? Constants.CommonCecilConstants.InterfaceMethodAttributes 
+                ? Constants.Cecil.InterfaceMethodAttributes 
                 : node.Modifiers.MethodModifiersToCecil((targetEnum, modifiers, defaultAccessibility) => ModifiersToCecil(modifiers, targetEnum, defaultAccessibility), "MethodAttributes.SpecialName");
 
             return accessorModifiers;

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -949,7 +949,7 @@ namespace Cecilifier.Core.AST
             }
 
             // if this is an *unqualified* access we need to load *this*
-            if ((parentMae == null || parentMae.Expression == node) && !node.Parent.IsKind(SyntaxKind.MemberBindingExpression))
+            if ((parentMae == null || parentMae.Expression == node) && !node.Parent.IsKind(SyntaxKind.MemberBindingExpression) && !propertySymbol.IsStatic)
             {
                 Context.EmitCilInstruction(ilVar, OpCodes.Ldarg_0);
             }

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -542,6 +542,14 @@ namespace Cecilifier.Core.AST
             var ctorInfo = Context.SemanticModel.GetSymbolInfo(node);
 
             var ctor = (IMethodSymbol) ctorInfo.Symbol;
+            if (ctor == null)
+            {
+                if (!TryProcessMethodReferenceInObjectCreationExpression(node))
+                    throw new InvalidOperationException($"Failed to resolve called constructor symbol in {node}");
+                
+                return;
+            }
+            
             if (TryProcessInvocationOnParameterlessImplicitCtorOnValueType(node, ctorInfo))
             {
                 return;
@@ -550,7 +558,7 @@ namespace Cecilifier.Core.AST
             var varName = Context.Naming.SyntheticVariable(ctor.ContainingType.Name, ElementKind.LocalVariable);
             EnsureForwardedMethod(Context, varName, ctor, Array.Empty<TypeParameterSyntax>());
 
-            string operand = ctor.MethodResolverExpression(Context);
+            var operand = ctor.MethodResolverExpression(Context);
             Context.EmitCilInstruction(ilVar, OpCodes.Newobj, operand);
             PushCall();
 
@@ -559,7 +567,7 @@ namespace Cecilifier.Core.AST
             
             StoreTopOfStackInLocalVariableAndLoadItsAddressIfNeeded(node);
         }
-        
+
         public override void VisitExpressionStatement(ExpressionStatementSyntax node)
         {
             base.Visit(node.Expression);
@@ -713,6 +721,18 @@ namespace Cecilifier.Core.AST
         public override void VisitDefaultExpression(DefaultExpressionSyntax node) => LogUnsupportedSyntax(node);
         public override void VisitSizeOfExpression(SizeOfExpressionSyntax node) => LogUnsupportedSyntax(node);
 
+        private bool TryProcessMethodReferenceInObjectCreationExpression(ObjectCreationExpressionSyntax node)
+        {
+            var arg = node.ArgumentList?.Arguments.SingleOrDefault();
+            if (arg != null && Context.SemanticModel.GetSymbolInfo(arg.Expression).Symbol is { Kind: SymbolKind.Method })
+            {
+                VisitIdentifierName((IdentifierNameSyntax)arg.Expression);
+                return true;
+            }
+
+            return false;
+        }
+        
         private void ProcessPrefixPostfixOperators(ExpressionSyntax operand, OpCode opCode, bool isPrefix)
         {
             using var _ = LineInformationTracker.Track(Context, operand);
@@ -856,7 +876,7 @@ namespace Cecilifier.Core.AST
         
         private bool TryProcessInvocationOnParameterlessImplicitCtorOnValueType(ObjectCreationExpressionSyntax node, SymbolInfo ctorInfo)
         {
-            if (ctorInfo.Symbol?.IsImplicitlyDeclared == false || ctorInfo.Symbol.ContainingType.IsReferenceType)
+            if (ctorInfo.Symbol == null || ctorInfo.Symbol.IsImplicitlyDeclared == false || ctorInfo.Symbol.ContainingType.IsReferenceType)
                 return false;
 
             new ValueTypeNoArgCtorInvocationVisitor(Context, ilVar, ctorInfo).Visit(node.Parent);
@@ -1081,7 +1101,11 @@ namespace Cecilifier.Core.AST
                 
             var delegateType = firstParentNotPartOfName switch
             {
-                ArgumentSyntax arg => ((IMethodSymbol) Context.SemanticModel.GetSymbolInfo(arg.Parent.Parent).Symbol).Parameters[arg.FirstAncestorOrSelf<ArgumentListSyntax>().Arguments.IndexOf(arg)].Type,
+                // assumes that a method reference in a object creation expression can only be a delegate instantiation.
+                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.ObjectCreationExpression } arg => Context.SemanticModel.GetTypeInfo(arg.Parent.Parent).Type, 
+                
+                // assumes that a method reference in an invocation expression is method group -> delegate conversion. 
+                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.InvocationExpression } arg => ((IMethodSymbol) Context.SemanticModel.GetSymbolInfo(arg.Parent.Parent).Symbol).Parameters[arg.FirstAncestorOrSelf<ArgumentListSyntax>().Arguments.IndexOf(arg)].Type,
                 
                 AssignmentExpressionSyntax assignment => Context.SemanticModel.GetSymbolInfo(assignment.Left).Symbol.Accept(ElementTypeSymbolResolver.Instance),
                     

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -271,7 +271,7 @@ namespace Cecilifier.Core.AST
             {
                 if (node.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
                 {
-                    typeAttributes = typeAttributes.AppendModifier("TypeAttributes.Abstract | TypeAttributes.Sealed");
+                    typeAttributes = typeAttributes.AppendModifier(Constants.Cecil.StaticTypeAttributes);
                 }
                 return typeAttributes.AppendModifier(ModifiersToCecil(node.Modifiers.Where(m => !m.IsKind(SyntaxKind.StaticKeyword)), m => "TypeAttributes.Nested" + m.ValueText.PascalCase()));
             }

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
@@ -76,7 +76,7 @@ internal partial class TypeDeclarationVisitor
                 Context,
                 endInvokeMethodVar,
                 "EndInvoke",
-                Constants.CommonCecilConstants.DelegateMethodAttributes,
+                Constants.Cecil.DelegateMethodAttributes,
                 Context.GetTypeInfo(node.ReturnType).Type,
                 false,
                 Array.Empty<TypeParameterSyntax>()
@@ -105,7 +105,7 @@ internal partial class TypeDeclarationVisitor
         {
             var methodLocalVar = Context.Naming.SyntheticVariable(methodName, ElementKind.Method);
             AddCecilExpression(
-                $@"var {methodLocalVar} = new MethodDefinition(""{methodName}"", {Constants.CommonCecilConstants.DelegateMethodAttributes}, {resolvedReturnType})
+                $@"var {methodLocalVar} = new MethodDefinition(""{methodName}"", {Constants.Cecil.DelegateMethodAttributes}, {resolvedReturnType})
 				{{
 					HasThis = true,
 					IsRuntime = true,

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
@@ -116,24 +116,6 @@ namespace Cecilifier.Core.AST
             return Context.TypeResolver.Resolve(classSymbol.BaseType);
         }
 
-        private IEnumerable<string> ImplementedInterfacesFor(BaseListSyntax bases)
-        {
-            if (bases == null)
-            {
-                yield break;
-            }
-
-            foreach (var @base in bases.Types)
-            {
-                var info = Context.GetTypeInfo(@base.Type);
-                if (info.Type?.TypeKind == TypeKind.Interface)
-                {
-                    var itfFQName = @base.DescendantTokens().Aggregate("", (acc, curr) => acc + curr.ValueText);
-                    yield return itfFQName;
-                }
-            }
-        }
-
         private void HandleTypeDeclaration(TypeDeclarationSyntax node, string varName)
         {
             var typeSymbol = DeclaredSymbolFor(node);

--- a/Cecilifier.Core/Cecilifier.Core.csproj
+++ b/Cecilifier.Core/Cecilifier.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.50.0</AssemblyVersion>
+    <AssemblyVersion>1.60.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/Cecilifier.Core/Constants.cs
+++ b/Cecilifier.Core/Constants.cs
@@ -2,39 +2,34 @@ namespace Cecilifier.Core;
 
 public struct Constants
 {
-    public static ContextFlagsValues ContextFlags = new();
-    public static ParameterAttributesValues ParameterAttributes = new();
-    public static CecilCommonConstants CommonCecilConstants = new();
-    
     public const string AssemblyReferenceCacheBasePath = "/tmp/CecilifierUserAssemblyReferenceCache";
 
-    public struct CecilCommonConstants
+    public struct Cecil
     {
-        public readonly string StaticFieldAttributes = "FieldAttributes.Public | FieldAttributes.Static";
-        public readonly string StaticClassAttributes = "TypeAttributes.AnsiClass | TypeAttributes.Sealed | TypeAttributes.Abstract | TypeAttributes.BeforeFieldInit";
-        public readonly string InterfaceMethodAttributes = "MethodAttributes.SpecialName | MethodAttributes.Public | MethodAttributes.NewSlot | MethodAttributes.Virtual | MethodAttributes.Abstract | MethodAttributes.HideBySig";
-        public readonly string MethodAttributesSpecialName = "MethodAttributes.SpecialName";
-        public readonly string DelegateMethodAttributes = "MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual";
-        public readonly string CtorAttributes = "MethodAttributes.RTSpecialName | MethodAttributes.SpecialName";
+        public const string StaticFieldAttributes = "FieldAttributes.Public | FieldAttributes.Static";
+        public const string StaticTypeAttributes = "TypeAttributes.Abstract | TypeAttributes.Sealed";
+        public const string StaticClassAttributes = $"TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | {StaticTypeAttributes}";
+        public const string InterfaceMethodAttributes = "MethodAttributes.SpecialName | MethodAttributes.Public | MethodAttributes.NewSlot | MethodAttributes.Virtual | MethodAttributes.Abstract | MethodAttributes.HideBySig";
+        public const string MethodAttributesSpecialName = "MethodAttributes.SpecialName";
+        public const string DelegateMethodAttributes = "MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual";
         
-        public readonly string InstanceConstructorName = "ctor";
-        public readonly string StaticConstructorName = "cctor";
+        public const string CtorAttributes = "MethodAttributes.RTSpecialName | MethodAttributes.SpecialName";
+        public const string InstanceConstructorName = "ctor";
+        public const string StaticConstructorName = "cctor";
 
 
-        public CecilCommonConstants() { }
+        public Cecil() { }
     }
     
-    public struct ParameterAttributesValues
+    public struct ParameterAttributes
     {
-        public readonly string None = "ParameterAttributes.None";
-        public readonly string In = "ParameterAttributes.In";
-        public readonly string Out = "ParameterAttributes.Out";
-        public readonly string Optional = "ParameterAttributes.Optional";
-
-        public ParameterAttributesValues() { }
+        public const string None = "ParameterAttributes.None";
+        public const string In = "ParameterAttributes.In";
+        public const string Out = "ParameterAttributes.Out";
+        public const string Optional = "ParameterAttributes.Optional";
     }
     
-    public struct ContextFlagsValues
+    public struct ContextFlags
     {
         /// <summary>
         /// In expressions such as `Index i; i = ^10` the assignment is actually a call to the Index constructor which in IL
@@ -42,13 +37,11 @@ public struct Constants
         /// normal store local, field, parameter). This will take place when we are visiting the lhs of the expression, so
         /// we turn on a flag to indicate that the address of the lhs should be loaded  
         /// </summary>
-        public readonly string PseudoAssignmentToIndex = "pseudo-assignment-to-index";
-        public readonly string HasStackallocArguments = "has-stackalloc-argument";
-        public readonly string RefReturn = "ref-return";
-        public readonly string Fixed = "fixed";
-        public readonly string InRangeExpression = "in-range-expressions";
-
-        public ContextFlagsValues() { }
+        public const string PseudoAssignmentToIndex = "pseudo-assignment-to-index";
+        public const string HasStackallocArguments = "has-stackalloc-argument";
+        public const string RefReturn = "ref-return";
+        public const string Fixed = "fixed";
+        public const string InRangeExpression = "in-range-expressions";
     }
 }
 

--- a/Cecilifier.Core/Extensions/CecilifierExtensions.cs
+++ b/Cecilifier.Core/Extensions/CecilifierExtensions.cs
@@ -51,7 +51,8 @@ namespace Cecilifier.Core.Extensions
         {
             var moduleKind = entryPointVar == null ? "ModuleKind.Dll" : "ModuleKind.Console";
             var entryPointStatement = entryPointVar != null ? $"\t\t\tassembly.EntryPoint = {entryPointVar};\n" : string.Empty;
-                 
+
+            const string runtimeConfigJsonExt = ".runtimeconfig.json";
             return $@"using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -71,6 +72,12 @@ public class SnippetRunner
         {{
 {cecilSnippet}{entryPointStatement}
 		    assembly.Write(args[0]);
+
+            //Writes a {runtimeConfigJsonExt} file matching the output assembly name.
+			File.Copy(
+				Path.ChangeExtension(typeof(SnippetRunner).Assembly.Location, ""{runtimeConfigJsonExt}""),
+                Path.ChangeExtension(args[0], ""{runtimeConfigJsonExt}""),
+                true);
         }}
 	}}
 }}";

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -57,7 +57,7 @@ namespace Cecilifier.Core.Misc
             var ctorName = Utils.ConstructorMethodName(isStatic);
             context.DefinitionVariables.RegisterMethod(typeName, ctorName, paramTypes, ctorLocalVar);
 
-            var exp = $@"var {ctorLocalVar} = new MethodDefinition(""{ctorName}"", {methodAccessibility} | MethodAttributes.HideBySig | {Constants.CommonCecilConstants.CtorAttributes}, assembly.MainModule.TypeSystem.Void)";
+            var exp = $@"var {ctorLocalVar} = new MethodDefinition(""{ctorName}"", {methodAccessibility} | MethodAttributes.HideBySig | {Constants.Cecil.CtorAttributes}, assembly.MainModule.TypeSystem.Void)";
             if (methodDefinitionPropertyValues != null)
             {
                 exp = exp + $"{{ {methodDefinitionPropertyValues} }}";

--- a/Cecilifier.Core/Misc/StaticDelegateCacheContext.cs
+++ b/Cecilifier.Core/Misc/StaticDelegateCacheContext.cs
@@ -66,7 +66,7 @@ public struct StaticDelegateCacheContext
         cacheTypeVar.Properties[counterName] = ++staticMethodToDelegateConversionCount;
 
         CacheBackingField = context.Naming.SyntheticVariable("cachedDelegate", ElementKind.Field);
-        var fieldExps = CecilDefinitionsFactory.Field(context, cacheInnerTypeName, cacheTypeVar, CacheBackingField, backingFieldName, delegateType, Constants.CommonCecilConstants.StaticFieldAttributes);
+        var fieldExps = CecilDefinitionsFactory.Field(context, cacheInnerTypeName, cacheTypeVar, CacheBackingField, backingFieldName, delegateType, Constants.Cecil.StaticFieldAttributes);
         foreach (var exp in fieldExps)
         {
             context.WriteCecilExpression(exp);
@@ -84,7 +84,7 @@ public struct StaticDelegateCacheContext
             cachedTypeVar,
             cacheTypeName,
             DeclaringTypeName,
-            Constants.CommonCecilConstants.StaticClassAttributes.AppendModifier("TypeAttributes.NestedPrivate"),
+            Constants.Cecil.StaticClassAttributes.AppendModifier("TypeAttributes.NestedPrivate"),
             context.TypeResolver.Bcl.System.Object,
             isStructWithNoFields: false,
             Array.Empty<string>());

--- a/Cecilifier.Core/Misc/Utils.cs
+++ b/Cecilifier.Core/Misc/Utils.cs
@@ -10,7 +10,7 @@ namespace Cecilifier.Core.Misc
 {
     internal struct Utils
     {
-        public static string ConstructorMethodName(bool isStatic) => $".{ (isStatic ? Constants.CommonCecilConstants.StaticConstructorName : Constants.CommonCecilConstants.InstanceConstructorName)}";
+        public static string ConstructorMethodName(bool isStatic) => $".{ (isStatic ? Constants.Cecil.StaticConstructorName : Constants.Cecil.InstanceConstructorName)}";
 
         public static string ImportFromMainModule(string expression) => $"assembly.MainModule.ImportReference({expression})";
 

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.50.0</AssemblyVersion>
+    <AssemblyVersion>1.60.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cecilifier.Web/Cecilifier.Web.csproj
+++ b/Cecilifier.Web/Cecilifier.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.50.0</AssemblyVersion>
+    <AssemblyVersion>1.60.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cecilifier.Web/Pages/Shared/_Layout.cshtml
+++ b/Cecilifier.Web/Pages/Shared/_Layout.cshtml
@@ -117,7 +117,7 @@
                 <a class="fab fa-twitter" href="https://twitter.com/adrianoverona"target="_tw_cecilifier"></a>
                 <a class="fab fa-blogger" href="https://programing-fun.blogspot.com/"target="_bs_cecilifier"></a>
                 <a class="fab fa-stack-overflow" href="https://stackoverflow.com/users/157321/vagaus"target="_so_cecilifier"></a>
-                <a class="fab fa-patreon" href="https://www.patreon.com/cecilifier"target="_pa_cecilifier"></a>
+                <a class="fab fa-github" href="https://github.com/sponsors/adrianoc"target="_ghs_cecilifier"></a>
                 <a class="fab fa-discord" href="https://discord.gg/dhF5BCW"target="_pa_cecilifier"></a>
                 | &copy; 2022 - Adriano Carlos Verona (<span id="cecilified_counter">@CecilifierApplication.Count</span>)
             </div>            


### PR DESCRIPTION
- updates sponsor info patreon -> github sponsors
- fixes NRE when handling explicit delegate instantiation (#190)
- refactors constants to use const instead of readonly fields
- fixes TypeAttributes for static top level/inner types (#191)
- copies .runtimeconfig.json file when running the cecilified code (#189)
- do not load implicit 'this' for static property access (#187)
 -bumps Cecilifier version to 1.60

