### PR TITLE
Merge current staging into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 ## [Unreleased]
 - bumped cecilifier version to 1.70.0
-
-## [Unreleased]
-- bumped cecilifier version to 1.60.0
 - fixed NRE when handling explicit delegate instantiation (#190)
 - fixed TypeAttributes for static top level/inner types (#191)
 - change code to copy .runtimeconfig.json file when running the cecilified code (#189)
 - do not load implicit 'this' for static property access (#187)
+- sorts type declaration to avoid intermixed code by processing types before its dependants.
 
 ## 15/Sept/2022
-
 ## Changed
 
 - bumped cecilifier version to 1.50.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
+- bumped cecilifier version to 1.70.0
 
+## [Unreleased]
 - bumped cecilifier version to 1.60.0
 - fixed NRE when handling explicit delegate instantiation (#190)
 - fixed TypeAttributes for static top level/inner types (#191)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,33 @@
 ## [Unreleased]
+
+## 22/Nov/2022
+
+## Changed
 - bumped cecilifier version to 1.70.0
+- type declaration are sorted before being processed to avoid intermixed
+  code by processing types before its dependents.
+
+## Fixed
+- do not load implicit 'this' for static property access (#187)
+- fixed forward type references to type parameters assuming type is extern (#188)
+- change code to copy .runtimeconfig.json file when running the cecilified code (#189)
 - fixed NRE when handling explicit delegate instantiation (#190)
 - fixed TypeAttributes for static top level/inner types (#191)
-- change code to copy .runtimeconfig.json file when running the cecilified code (#189)
-- do not load implicit 'this' for static property access (#187)
-- sorts type declaration to avoid intermixed code by processing types before its dependants.
+- fixed forward type references in field declarations assuming type is extern (#196)
+- fixed compound assignment handling (#197)
 
 ## 15/Sept/2022
 ## Changed
-
 - bumped cecilifier version to 1.50.0
 - updated testing section of README.md
 
 ## Added
-
 - support for covariant properties (#179)
 - support for covariant return methods (#179)
 - support for using statement (#177)
 - support for modulus operator (%)
 
 ## Fixed
-
 - static automatic properties being handled as instance ones (#183)
 - forwarded field references generating invalid code (#182)
 - forwarded attribute usage (#180)

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -4,15 +4,15 @@
       <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-4.final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cecilifier.Core\Cecilifier.Core.csproj" />

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
       <TargetFramework>net6.0</TargetFramework>
       <LangVersion>10</LangVersion>
+      <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/Cecilifier.Core.Tests/Framework/AssemblyDiff/Utils.cs
+++ b/Cecilifier.Core.Tests/Framework/AssemblyDiff/Utils.cs
@@ -96,7 +96,8 @@ namespace Cecilifier.Core.Tests.Framework.AssemblyDiff
             "System.Runtime.CompilerServices.IsUnmanagedAttribute",
             "System.Runtime.CompilerServices.NullableContextAttribute",
             "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
-            "System.Runtime.CompilerServices.IsReadOnlyAttribute"
+            "System.Runtime.CompilerServices.IsReadOnlyAttribute",
+            "System.Runtime.CompilerServices.RefSafetyRulesAttribute"
         };
     }
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Types/ReadOnlyStruct.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Types/ReadOnlyStruct.cs.txt
@@ -1,0 +1,9 @@
+readonly struct ReadOnlyStruct
+{
+    public readonly int field;
+}
+
+class Driver
+{
+    int Foo(ReadOnlyStruct ros) => ros.field + 1;
+}

--- a/Cecilifier.Core.Tests/Tests/Integration/Types/TypesTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/Types/TypesTestCase.cs
@@ -104,5 +104,11 @@ namespace Cecilifier.Core.Tests.Integration.Types
         {
             AssertResourceTest(@"Types/TypeInitializer");
         }
+        
+        [Test]
+        public void ReadOnlyStructTest()
+        {
+            AssertResourceTest(@"Types/ReadOnlyStruct");
+        }
     }
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
@@ -32,8 +32,8 @@ public class DelegateTests : CecilifierUnitTestBase
         var result = RunCecilifier("class C { public delegate int D(); D M(D p) => p; }");
         var cecilifiedCode = result.GeneratedCode.ReadToEnd();
         
-        Assert.That(cecilifiedCode, Does.Match(@"var m_M_\d+ = new MethodDefinition\(""M"",.+, del_D1\);"), "Return type");
-        Assert.That(cecilifiedCode, Does.Match(@"var p_p_\d+ = new ParameterDefinition\(""p"",.+del_D1\);"), "Parameter");
+        Assert.That(cecilifiedCode, Does.Match(@"var m_M_\d+ = new MethodDefinition\(""M"",.+, del_D\d+\);"), "Return type");
+        Assert.That(cecilifiedCode, Does.Match(@"var p_p_\d+ = new ParameterDefinition\(""p"",.+del_D\d+\);"), "Parameter");
     }
 
     [Test]

--- a/Cecilifier.Core.Tests/Tests/Unit/FormattingOptionsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/FormattingOptionsTests.cs
@@ -59,6 +59,9 @@ namespace Cecilifier.Core.Tests.Tests.Unit
         [Test, Combinatorial]
         public void Casing_Setting_Is_Respected([Values] ElementKind elementKind, [Values] bool camelCasing)
         {
+            if (elementKind == ElementKind.None)
+                return;
+            
             if (elementKind == ElementKind.Label && !camelCasing)
             {
                 Assert.Ignore("as of Aug/2021 all created labels are camelCase.");

--- a/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
@@ -76,8 +76,8 @@ class Foo
     [TestCase("where T : IFoo", "string ConstrainedToInterfaceCallToString() => field.ToString();", "Ldflda, fld_field_6", "Constrained, gp_T_3")]
     [TestCase("", "string Unconstrained() => field.ToString();", "Ldflda, fld_field_6", "Constrained, gp_T_3")]
     [TestCase("where T : class", "string ConstrainedToReferenceType() => field.ToString();", "Ldfld, fld_field_6", "Box, gp_T_3")]
-    [TestCase("where T: Bar", "string ConstrainedToClassCallToString() => field.ToString();", "Ldfld, fld_field_6", "Box, gp_T_3")]
-    [TestCase("where T: Bar", "void ConstrainedToClassCallClassMethod() => field.M();", "Ldfld, fld_field_6", "Box, gp_T_3")]
+    [TestCase("where T: Bar", "string ConstrainedToClassCallToString() => field.ToString();", "Ldfld, fld_field_11", "Box, gp_T_8")]
+    [TestCase("where T: Bar", "void ConstrainedToClassCallClassMethod() => field.M();", "Ldfld, fld_field_11", "Box, gp_T_8")]
     public void TestCallOn_TypeParameter_CallOnField(string constraint, string snippet, params string[] expectedExpressions)
     {
         var code =$@"interface IFoo {{ string Get(); }}

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
@@ -97,7 +97,7 @@ public class Foo
 
             var cecilifiedCode = result.GeneratedCode.ReadToEnd();
             Assert.False(cecilifiedCode.Contains("FieldDefinition(\"file\", FieldAttributes.Public, st_fileStream_0);"), cecilifiedCode);
-            Assert.True(cecilifiedCode.Contains("FieldDefinition(\"definedInFooBar\", FieldAttributes.Public, st_fileStream_0);"), cecilifiedCode);
+            Assert.True(cecilifiedCode.Contains("FieldDefinition(\"definedInFooBar\", FieldAttributes.Public, st_fileStream_3);"), cecilifiedCode);
             Assert.True(cecilifiedCode.Contains("FieldDefinition(\"file\", FieldAttributes.Public, assembly.MainModule.ImportReference(typeof(System.IO.FileStream)));"), cecilifiedCode);
         }
 

--- a/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
@@ -106,6 +106,40 @@ public class OperatorsTests : CecilifierUnitTestBase
                         @"\2Newobj,.+""System.Nullable`1"", "".ctor"".+,""System.Int32"", ""System.Int32"".+;\s+" +
                         @"il_M_3.Append\(lbl_conditionEnd_7\);"));
     }
+
+    [TestCase(
+        "int i = 42; i -= 10;", 
+        @"(il_topLevelMain_\d\.Emit\(OpCodes\.)Ldc_I4, 42\);\s+\1Stloc, (l_i_\d+)\);\s+\1Ldloc, \2\);\s+\1Ldc_I4, 10\);\s+\1Sub\);\s+\1Stloc, \2\);\s+m_topLevelStatements_1\.Body\.Instructions\.Add\(.+OpCodes\.Ret\)\);", 
+        TestName = "Numeric Primitive Subtraction")]
+    [TestCase(
+        "int i = 10; i += 32;", 
+        @"(il_topLevelMain_\d\.Emit\(OpCodes\.)Ldc_I4, 10\);\s+\1Stloc, (l_i_\d+)\);\s+\1Ldloc, \2\);\s+\1Ldc_I4, 32\);\s+\1Add\);\s+\1Stloc, \2\);\s+m_topLevelStatements_1\.Body\.Instructions\.Add\(.+OpCodes\.Ret\)\);", 
+        TestName = "Numeric Primitive Addition")]
+    [TestCase(
+        "int []a = new[] { 10 }; a[0] += 32; System.Console.WriteLine(a[0]);",
+        @"(il_topLevelMain_\d+\.Emit\(OpCodes\.)Ldc_I4, 1\);\s+\1Newarr, .+Int32\);\s+\1Dup\);\s+\1Ldc_I4, 0\);\s+\1Ldc_I4, 10\);\s+\1Stelem_I4\);\s+\1Stloc, (l_a_\d+)\);\s+\1Ldloc, \2\);\s+\1Ldc_I4, 0\);\s+\1Ldloc, \2\);\s+\1Ldc_I4, 0\);\s+\1Ldelem_I4\);\s+\1Ldc_I4, 32\);\s+\1Add\);\s+\1Stelem_I4\);",
+        TestName = "Array Numeric Primitive")]
+    [TestCase(
+        "string s = \"10\"; s += \"32\";", 
+        @"(il_topLevelMain_\d\.Emit\(OpCodes\.)Ldstr, ""10""\);\s+\1Stloc, (l_s_\d+)\);\s+\1Ldloc, \2\);\s+\1Ldstr, ""32""\);\s+\1Call, .+Import\(typeof\(string\)\.GetMethod\(""Concat"".+\)\);\s+\1Stloc, \2\);\s+m_topLevelStatements_1\.Body\.Instructions\.Add\(.+OpCodes\.Ret\)\);", 
+        TestName = "String")]
+    [TestCase(
+        "C c = new C(); c += 42; class C { public static C operator+(C c, int i) => c; }", 
+        @"il_topLevelMain_\d+\.Emit\(OpCodes\.Call, m_op_Addition_\d+\);", 
+        TestName = "Overloaded + (forwarded)")]
+    [TestCase(
+        "class D { void M() { C c = new C(); c += 42; } } class C { public static C operator+(C c, int i) => c; }", 
+         @"(il_M_\d+\.Emit\(OpCodes\.)Ldloc, l_c_10\);\s+\1Ldc_I4, 42\);\s+\1Call, m_op_Addition_1\);\s+\1Stloc, l_c_10\);", 
+        TestName = "Overloaded +")]
+    [TestCase(
+        "var c = new C(); c.M(c); System.Console.WriteLine(c.Value); class C { public int Value {get; set;} public void M(C other) { Value += 1; other.Value += 2; } }", 
+        @"//Value \+= 1;\s+var (ldarg_0_\d+) = il_M_19.Create\(OpCodes.Ldarg_0\);\s+il_M_19.Append\(\1\);\s+(il_M_\d+\.Emit\(OpCodes\.)Ldarg_0\);\s+\2Call, m_get_12\);\s+\2Ldc_I4, 1\);\s+\2Add\);\s+\2Call, l_set_15\);\s+", 
+        TestName = "Properties (numeric)")]
+    public void TestCompoundAssignment(string code, string expected)
+    {
+        var result = RunCecilifier(code);
+        Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(expected));
+    }
     
     [TestCaseSource(nameof(NullConditionalOperatorOnComplexTargetsScenarios))]
     public void TestNullConditionalOperatorOnComplexTargets(string target, string expectedIlRegexForLoadingTarget)

--- a/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
@@ -141,8 +141,8 @@ public class OperatorsTests : CecilifierUnitTestBase
     [TestCase("long M(long a) => a % 3L;", @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+\1Ldc_I8, 3L\);\s+\1Rem\);\s+")]
     [TestCase("float M(float a) => a % 3;", @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+\1Ldc_I4, 3\);\s+\1Conv_R4\);\s+\1Rem\);\s+")]
     [TestCase("double M(double a) => a % 3;", @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+\1Ldc_I4, 3\);\s+\1Conv_R8\);\s+\1Rem\);\s+")]
-    //[TestCase("decimal M(decimal a) => a % 3;")] // This is covered by the integration test.
-    public void T(string methodWithModulus, string expected = @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+(?:\1Conv_I4\);\s+)?\1Ldc_I4, 3\);\s+\1Rem\);\s+")
+    [TestCase("decimal M(decimal a) => a % 3;", @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+\1Ldc_I4, 3\);\s+\1Newobj.+System\.Decimal.+\);\s+\1Call,.+op_Modulus.+\);")]
+    public void TestModulus(string methodWithModulus, string expected = @"(il_M_2\.Emit\(OpCodes\.)Ldarg_1\);\s+(?:\1Conv_I4\);\s+)?\1Ldc_I4, 3\);\s+\1Rem\);\s+")
     {
         var result = RunCecilifier($"class Foo {{ {methodWithModulus } }}");
         Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(expected));

--- a/Cecilifier.Core.Tests/Tests/Unit/PropertyTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/PropertyTests.cs
@@ -99,7 +99,7 @@ public class PropertyTests : CecilifierUnitTestBase
         var result = RunCecilifier("class C { public static int Prop { get; set; } } class Driver { int M() => C.Prop; }");
         var cecilifiedCode = result.GeneratedCode.ReadToEnd();
         
-        Assert.That(cecilifiedCode, Does.Match(@"var fld_prop_\d+ = new FieldDefinition\(""<Prop>k__BackingField"", .+FieldAttributes\.Static.+\);"), "Backing field should be static");
+        Assert.That(cecilifiedCode, Does.Match(@"var fld_prop_\d+ = new FieldDefinition\(""<Prop>k__BackingField"",.+FieldAttributes\.Static.+\);"), "Backing field should be static");
         Assert.That(cecilifiedCode, Does.Match(@"var l_set_\d+ = new MethodDefinition\(""set_Prop"", .+MethodAttributes\.Static.+\);"), "Setter should be static");
         Assert.That(cecilifiedCode, Does.Match(@"var m_get_\d+ = new MethodDefinition\(""get_Prop"", .+MethodAttributes\.Static.+\);"), "Getter should be static");
         Assert.That(cecilifiedCode, Does.Match(@"il_set_\d+.Emit\(OpCodes.Stsfld, fld_prop_\d+\);"), "Setter field access should be static");

--- a/Cecilifier.Core.Tests/Tests/Unit/StackallocTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StackallocTests.cs
@@ -95,7 +95,7 @@ public class StackallocTests : CecilifierUnitTestBase
             var expectedLines = new[]
             {
                 "il_bar_2.Emit(OpCodes.Ldc_I4, 4000);", "il_bar_2.Emit(OpCodes.Conv_U);", "il_bar_2.Emit(OpCodes.Localloc);", "il_bar_2.Emit(OpCodes.Ldc_I4, 4000);",
-                "var l_spanCtor_5 = new MethodReference(\".ctor\", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference(typeof(Span<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.Int32)) { HasThis = true };",
+                "var l_spanCtor_5 = new MethodReference(\".ctor\", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference(typeof(System.Span<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.Int32)) { HasThis = true };",
                 "l_spanCtor_5.Parameters.Add(new ParameterDefinition(\"ptr\", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(void*))));",
                 "l_spanCtor_5.Parameters.Add(new ParameterDefinition(\"length\", ParameterAttributes.None, assembly.MainModule.TypeSystem.Int32));",
                 "il_bar_2.Emit(OpCodes.Newobj, assembly.MainModule.ImportReference(l_spanCtor_5));", "il_bar_2.Emit(OpCodes.Call, m_bar_1);", "il_bar_2.Emit(OpCodes.Ret);",
@@ -117,7 +117,7 @@ public class StackallocTests : CecilifierUnitTestBase
             {
                 "il_bar_3.Emit(OpCodes.Ldsfld, fld_countField_1);", "il_bar_3.Emit(OpCodes.Conv_U);", "il_bar_3.Emit(OpCodes.Sizeof, assembly.MainModule.TypeSystem.Int32);", "il_bar_3.Emit(OpCodes.Mul_Ovf_Un);",
                 "il_bar_3.Emit(OpCodes.Localloc);", "il_bar_3.Emit(OpCodes.Ldfld, fld_countField_1);",
-                "var l_spanCtor_6 = new MethodReference(\".ctor\", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference(typeof(Span<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.Int32)) { HasThis = true };",
+                "var l_spanCtor_6 = new MethodReference(\".ctor\", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference(typeof(System.Span<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.Int32)) { HasThis = true };",
                 "l_spanCtor_6.Parameters.Add(new ParameterDefinition(\"ptr\", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(void*))));",
                 "l_spanCtor_6.Parameters.Add(new ParameterDefinition(\"length\", ParameterAttributes.None, assembly.MainModule.TypeSystem.Int32));",
                 "il_bar_3.Emit(OpCodes.Newobj, assembly.MainModule.ImportReference(l_spanCtor_6));", "il_bar_3.Emit(OpCodes.Call, m_bar_2);", "il_bar_3.Emit(OpCodes.Ret);",
@@ -175,7 +175,7 @@ public class StackallocTests : CecilifierUnitTestBase
             var cecilifiedCode = result.GeneratedCode.ReadToEnd();
 
             Assert.That(cecilifiedCode, Does.Match(
-                @"var (l_spanCtor_\d+) = new MethodReference\("".ctor"", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference\(typeof\(Span<>\)\).MakeGenericInstanceType\(.+TypeSystem.Int32\)\) { HasThis = true };\s+" +
+                @"var (l_spanCtor_\d+) = new MethodReference\("".ctor"", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference\(typeof\(System\.Span<>\)\).MakeGenericInstanceType\(.+TypeSystem.Int32\)\) { HasThis = true };\s+" +
                 @"\1.Parameters.Add\(.+""ptr"".+void\*.+\);\s+" +
                 @"\1.Parameters.Add\(.+""length"".+TypeSystem.Int32.+\);\s+" +
                 @"il_M_\d+.Emit\(OpCodes.Newobj, assembly.MainModule.ImportReference\(\1\)\);"));
@@ -189,7 +189,7 @@ public class StackallocTests : CecilifierUnitTestBase
             var cecilifiedCode = result.GeneratedCode.ReadToEnd();
 
             Assert.That(cecilifiedCode, Does.Match(
-                @"var (l_spanCtor_\d+) = new MethodReference\("".ctor"", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference\(typeof\(Span<>\)\).MakeGenericInstanceType\(.+TypeSystem.Int32\)\) { HasThis = true };\s+" +
+                @"var (l_spanCtor_\d+) = new MethodReference\("".ctor"", assembly.MainModule.TypeSystem.Void, assembly.MainModule.ImportReference\(typeof\(System\.Span<>\)\).MakeGenericInstanceType\(.+TypeSystem.Int32\)\) { HasThis = true };\s+" +
                 @"\1.Parameters.Add\(.+""ptr"".+void\*.+\);\s+" +
                 @"\1.Parameters.Add\(.+""length"".+TypeSystem.Int32.+\);\s+" +
                 @"il_M_\d+.Emit\(OpCodes.Newobj, assembly.MainModule.ImportReference\(\1\)\);"));

--- a/Cecilifier.Core.Tests/Tests/Unit/StringTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StringTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class StringTests : CecilifierUnitTestBase
+{
+    [TestCase("const string rls = \"\"\"This \"is a\" test\"\"\"; System.Console.WriteLine(rls);", TestName = "Constant")]
+    [TestCase("System.Console.WriteLine(\"\"\"This \"is a\" test\"\"\");", TestName = "UsedAsParameter")]
+    [TestCase("Foo(); void Foo(string s = \"\"\"This \"is a\" test\"\"\") {}", TestName = "AsDefaultParameterValue")]
+    public void TestRawLiteralString(string code)
+    {
+        var result = RunCecilifier(code);
+
+        var cecilifiedCode = result.GeneratedCode.ReadToEnd();
+        Assert.That(cecilifiedCode, Contains.Substring("Ldstr, \"This \\\"is a\\\" test"));
+    }
+    
+    [TestCase(RawStringConstants.NoIndentation, RawStringConstants.ResultingNoIndentation)]
+    [TestCase(RawStringConstants.SimpleIndentation, RawStringConstants.ResultingSimpleIndentation)]
+    public void TestMultiLineRawLiteralString(string value, string expected)
+    {
+        Run($"var s = \"\"\"{value}\"\"\"; System.Console.WriteLine(s);", expected);
+    }
+    
+    [TestCase(RawStringConstants.NoIndentation, RawStringConstants.ResultingNoIndentation)]
+    [TestCase(RawStringConstants.SimpleIndentation, RawStringConstants.ResultingSimpleIndentation)]
+    public void TestMultiLineRawLiteralStringAsDefaultParameterValue(string value, string expected)
+    {
+        Run($"Foo(); void Foo(string s = \"\"\"{value}\"\"\") {{}}", expected);
+    }
+
+    private static void Run(string code, string expectedString)
+    {
+        var result = RunCecilifier(code);
+
+        var cecilifiedCode = result.GeneratedCode.ReadToEnd();
+        Assert.That(cecilifiedCode, Contains.Substring($"Ldstr, \"{expectedString}\""));
+    }
+}
+
+struct RawStringConstants
+{
+    public const string NoIndentation = "\nA\n              \nB\n";
+    public const string ResultingNoIndentation = "A\\n              \\nB";
+    
+    public const string SimpleIndentation = "\n  A\n  B\n  ";
+    public const string ResultingSimpleIndentation = "A\\nB";
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
@@ -1,0 +1,14 @@
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class StructSpecificTests : CecilifierUnitTestBase
+{
+    [Test]
+    public void ReadOnlyStructDeclaration()
+    {
+        var result = RunCecilifier("readonly struct RO { }");
+        Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(@$"st_rO_\d+\.CustomAttributes\.Add\(new CustomAttribute\(.+""System.Runtime.CompilerServices.IsReadOnlyAttribute"", "".ctor"".+\)\);"));
+    }
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/SystemRangeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/SystemRangeTests.cs
@@ -102,12 +102,12 @@ public class SystemRangeTests : CecilifierUnitTestBase
         var indexedFromEnd = endIndex[0] == '^';
         var expected =
             @".+(il_M_\d+\.Emit\(OpCodes\.)Ldarg_2\);\s+" +
-            @"var (?<span_copy>.+SpanCopy_\d) = new VariableDefinition\(assembly.MainModule.ImportReference\(typeof\(System.Span<>\)\).MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);\s+" +
+            @"var (?<span_copy>.+SpanCopy_\d+) = new VariableDefinition\(assembly.MainModule.ImportReference\(typeof\(System.Span<>\)\).MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);\s+" +
             @"(?<body_var>.+)\.Variables.Add\(\k<span_copy>\);\s+" +
             @"\1Stloc, \k<span_copy>\);\s+" +
             @"\1Ldloca, \k<span_copy>\);\s+".IfTrue(indexedFromEnd) +
             @"\1(?:Ldc_I4, 2|Ldarg_1|Call, m_idx_\d)\);\s+" +
-            @"var (?<start_index>l_startIndex_\d) = new VariableDefinition\(assembly.MainModule.TypeSystem.Int32\);\s+" +
+            @"var (?<start_index>l_startIndex_\d+) = new VariableDefinition\(assembly.MainModule.TypeSystem.Int32\);\s+" +
             @"\k<body_var>.Variables.Add\(\k<start_index>\);\s+" +
             @"\1Stloc, \k<start_index>\);\s+" +
             @"\1Dup\);\s+" +

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using Cecilifier.Core.TypeDependency;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class TypeDependencyCollectorTests
+{
+    [Test]
+    public void Single_SyntaxTree()
+    {
+        var comp = CompilationFor("class Foo : Bar { } class Bar {}");
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Unordered.ToString(), Is.EqualTo("Foo,Bar"));
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo("Bar,Foo"));
+    }
+    
+    [Test]
+    public void Two_SyntaxTree()
+    {
+        var comp = CompilationFor("class Foo : Bar { }", "class Bar {}");
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Unordered.ToString(), Is.EqualTo("Foo,Bar"));
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo("Bar,Foo"));
+    }
+    
+    [TestCase("class A : B {} class B {}", "B,A", TestName = "As base type")]
+    [TestCase("class A { B b; } class B {}", "B,A", TestName = "As field")]
+    [TestCase("class A { B b { get; set; } } class B {}", "B,A", TestName = "As property")]
+    [TestCase("class A { event B b; } class B {}", "B,A", TestName = "As event as field")]
+    [TestCase("class A { event B b { add {} remove {} } } class B {}", "B,A", TestName = "As event full")]
+    [TestCase("class A { void M(B b) {} } class B {}", "B,A", TestName = "As parameter")]
+    [TestCase("class A { void M() { B b; } } class B {}", "B,A", TestName = "As local variable")]
+    [TestCase("class A { B M() => null; } class B {}", "B,A", TestName = "As return type")]
+    [TestCase("class A { string M() => nameof(B); } class B {}", "B,A", TestName = "As name of")]
+    [TestCase("class A { Type M() => typeof(B); class B {}", "B,A", TestName = "As type of")]
+    [TestCase("class A { void M(object o) { object b = (B) o; } class B {}", "B,A", TestName = "As cast target")]
+    [TestCase("class A { void M(object o) { object b = o as B; } class B {}", "B,A", TestName = "As *as* operator")]
+    [TestCase("class A { bool M(object o) => is B; } class B {}", "B,A", TestName = "As *is* operator")]
+    [TestCase("class A<T> { A<B> a; } class B {}", "B,A", TestName = "As type argument")]
+    [TestCase("class A<T> where T: B { } class B {}", "B,A", TestName = "As type constraint")]
+    [TestCase("class A { object M() => new B(); } class B {}", "B,A", TestName = "In object creation")]
+    [TestCase("class A { object M() => new B[0]; } class B {}", "B,A", TestName = "In Array")]
+    public void In_Various_Nodes(string code, string expected)
+    {
+        var comp = CompilationFor(code);
+        var collector = new TypeDependencyCollector(comp);
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo(expected));
+    }
+    
+    [TestCase("class A:B {} class B {}", "B,A", TestName = "Direct dependency")]
+    [TestCase("class A:B {} class B:C {} class C {}", "C,B,A", TestName = "Three level direct dependency")]
+    [TestCase("class A:B {} class B {} class C:B {}", "B,A,C", TestName = "Common dependency")]
+    [TestCase("class A:B {} class B { A a; }", "A,B", TestName = "Cyclic dependency")]
+    [TestCase("class A:B {} class B:C {} class C:A {}", "C,B,A", TestName = "Three level cyclic dependency")] 
+    [TestCase("class A { } class B {}", "A,B", TestName = "No dependency")]
+    public void References_Levels(string code, string expected)
+    {
+        var comp = CompilationFor(code);
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo(expected));
+    }
+    
+    [TestCase("class A { NS.B b; } namespace NS { class B {} }", "B,A", TestName = "Qualified namespace")]
+    [TestCase("using NS; class A { B b; } namespace NS { class B {} }", "B,A", TestName = "Unqualified namespace")]
+    public void TypeSyntax_Types(string code, string expected)
+    {
+        var comp = CompilationFor(code);
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo(expected));
+    }
+    
+    [TestCase("class A : B  {} class B {}", "B,A", TestName = "Class")]
+    [TestCase("class A { B b; } struct B {}", "B,A", TestName = "Struct")]
+    [TestCase("class A { IFoo foo; } interface IFoo {}", "IFoo,A", TestName = "Interfaces")]
+    [TestCase("class A { E e; } enum E {}", "E,A", TestName = "Enum")]
+    public void KindOfType(string code, string expected)
+    {
+        var comp = CompilationFor(code);
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo(expected));
+    }
+    
+    static CSharpCompilation CompilationFor(params string[] code)
+    {
+        var syntaxTrees = code.Select(source => CSharpSyntaxTree.ParseText(source));
+        var compilation = CSharpCompilation.Create("Test", syntaxTrees);
+        return compilation;
+    }
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
@@ -121,6 +121,17 @@ public class TypeDependencyCollectorTests
         
         Assert.That(collector.Ordered.ToString(), Is.EqualTo(expectedOrder));
     }
+
+    [TestCase("class A:B { B b1; B b2; } class B { A a; }", "B,A")]
+    [TestCase("class A:B { B b1; void M(B b) { } } class B { A a; }", "B,A", TestName =  "In Parameters")]
+    [TestCase("class A:B { B b1; B M() => this; } class B { A a; }", "B,A", TestName =  "In Return")]
+    public void NumberOfMemberReference_IsTakenIntoAccount_UponDependencyCycles(string code, string expectedOrder)
+    {
+        var comp = CompilationFor(code);
+        var collector = new TypeDependencyCollector(comp);
+        
+        Assert.That(collector.Ordered.ToString(), Is.EqualTo(expectedOrder));
+    }
     
     static CSharpCompilation CompilationFor(params string[] code)
     {

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeDependencyCollectorTests.cs
@@ -43,6 +43,7 @@ public class TypeDependencyCollectorTests
     [TestCase("class A { bool M(object o) => is B; } class B {}", "B,A", TestName = "As *is* operator")]
     [TestCase("class A<T> { A<B> a; } class B {}", "B,A", TestName = "As type argument")]
     [TestCase("class A<T> where T: B { } class B {}", "B,A", TestName = "As type constraint")]
+    [TestCase("class A : System.Collections.Generic.List<B> { } class B {}", "B,A", TestName = "As type argument")]
     [TestCase("class A { object M() => new B(); } class B {}", "B,A", TestName = "In object creation")]
     [TestCase("class A { object M() => new B[0]; } class B {}", "B,A", TestName = "In Array")]
     [TestCase("class A { object M() => B.M(); } class B { public static M() {} }", "B,A", TestName = "In static member reference")]

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeHelpersTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeHelpersTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Reflection;
+using Cecilifier.Runtime;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class TypeHelpersTests
+{
+    [TestCase(".ctor")]
+    [TestCase("M")]
+    public void ResolveMethod_Throws_IfTypeCannotBeFound(string methodName)
+    {
+        Assert.Throws<InvalidOperationException>(() => TypeHelpers.ResolveMethod(typeof(Foo).AssemblyQualifiedName, methodName, BindingFlags.Instance | BindingFlags.Public, string.Empty, Array.Empty<string>()));
+    }
+    
+    [Test]
+    public void ResolveField_Throws_IfTypeCannotBeFound()
+    {
+        Assert.Throws<Exception>(() => TypeHelpers.ResolveField("NonExistingType", "NotRelevant_TypeDoesNotExist"));
+    }
+    
+    [Test]
+    public void ResolveGenericMethod_Throws_IfNoMethodMatches()
+    {
+        Assert.Throws<MissingMethodException>(() => TypeHelpers.ResolveGenericMethod(typeof(string).FullName, "NotRelevant_TypeIsNotGeneric", BindingFlags.Public, Array.Empty<string>(), Array.Empty<ParamData>()));
+    }
+    
+    [Test]
+    public void ResolveGenericMethod_ReturnsNull_IfMethodNameMatchesButParameterListNot()
+    {
+        var resolveGenericMethod = TypeHelpers.ResolveGenericMethod(
+            typeof(Foo).AssemblyQualifiedName, 
+            "M", 
+            BindingFlags.Public | BindingFlags.Instance, 
+            new [] {"T"}, 
+            new [] { new ParamData() { FullName = "NotImportant "} });
+        
+        Assert.IsNull(resolveGenericMethod);
+    }
+
+    public class Foo
+    {
+        public void M<T>(int i) { }
+        public void M(int j) { }
+
+        public Foo(int j) { }
+    }
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeResolutionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeResolutionTests.cs
@@ -14,6 +14,52 @@ public class TypeResolutionTests : CecilifierUnitTestBase
         var cecilifiedCode = result.GeneratedCode.ReadToEnd();
         Assert.That(cecilifiedCode, Contains.Substring($"ImportReference(typeof({expectedFullyQualifiedName}))"));
     }
+    
+    [TestCase(
+        "class Foo : System.Collections.Generic.List<Bar> {} class Bar { Foo foo; }", 
+        @"cls_foo_\d+\.BaseType = .+ImportReference\(typeof\(.+Generic\.List\<\>\)\).MakeGenericInstanceType\(cls_bar_\d+\);",
+        TestName = "Generic argument in base type")]
+    
+    [TestCase(
+        "class Foo { System.Action<Bar> M() => null; } class Bar { Foo foo; }", 
+        @"m_M_\d+ = new MethodDefinition\(""M"",.+ImportReference\(typeof\(System.Action\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\);",
+        TestName = "Generic argument in return type")]
+    
+    [TestCase(
+        "class Foo { void M(System.Action<Bar> a) {} } class Bar { Foo foo; }", 
+        @"p_a_\d+ = new ParameterDefinition\(""a"", .+ImportReference\(typeof\(System\.Action\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\);",
+        TestName = "Generic argument in parameter")]
+
+    [TestCase(
+        "class Foo { System.Collections.Generic.List<Bar> _bars; } class Bar { Foo foo; }", 
+        @".+fld__bars_\d+ = new FieldDefinition\(""_bars"",.+ImportReference\(typeof\(.+Generic\.List\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\);",
+        TestName = "Generic argument in field")]
+    
+    [TestCase(
+        "class Foo { System.Collections.Generic.List<Bar> Bars => null; } class Bar { Foo foo; }", 
+        @".+prop_bars_\d+ = new PropertyDefinition\(""Bars"",.+ImportReference\(typeof\(.+Generic\.List\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\);",
+        TestName = "Generic argument in property")]
+    
+    [TestCase(
+        "using System; class Foo { event EventHandler<Bar> Bar; } class Bar : EventArgs { Foo foo; }", 
+        @".+fld_bar_\d+ = new FieldDefinition\(""Bar"",.+ImportReference\(typeof\(.+EventHandler\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\);\s+",
+        @"m_add_\d+.Parameters.Add\(new ParameterDefinition\(""value"",.+ImportReference\(typeof\(.+EventHandler\<\>\)\)\.MakeGenericInstanceType\(cls_bar_\d+\)\)\);",
+        TestName = "Generic argument in event")]
+    public void TypeForwardingCyclicTests(string code, params string []expected)
+    {
+        // Test access to a forward type declaration is handled correctly by ensuring the value passed to MakeGenericInstanceType is a variable holding a
+        // type definition (instead of resolving the type as if it was not declared in the compilation).
+        // This is validated by making sure that the related member definition (field, property, parameter, event, etc) references `cls_bar_x` (i.e, the
+        // variable holding the type definition for class bar instead trying to import it like ImportReference(typeof(Bar)))
+        //
+        // Important:
+        // All snippets used in the tests need to have 2 types referencing each other Foo <-> Bar in a way that there's no better order of 
+        // processing them without requiring a forward reference.
+        var result = RunCecilifier(code);
+        var cecilifiedCode = result.GeneratedCode.ReadToEnd();
+        foreach(var current in expected)
+            Assert.That(cecilifiedCode, Does.Match(current));
+    }
 
     private static IEnumerable ExternalTypeTestScenarios()
     {

--- a/Cecilifier.Core/AST/CompilationUnitVisitor.cs
+++ b/Cecilifier.Core/AST/CompilationUnitVisitor.cs
@@ -19,7 +19,7 @@ namespace Cecilifier.Core.AST
         {
             HandleAttributesInMemberDeclaration(node.AttributeLists, "assembly");
             base.VisitCompilationUnit(node);
-            NewMethod();
+            VisitDeclaredTypesSortedByDepenendecies();
         }
      
         public override void VisitGlobalStatement(GlobalStatementSyntax node)
@@ -43,7 +43,7 @@ namespace Cecilifier.Core.AST
             new TypeDeclarationVisitor(Context).Visit(node);
         }
 
-        private void NewMethod()
+        private void VisitDeclaredTypesSortedByDepenendecies()
         {
             var collectedTypes = new TypeDependency.TypeDependencyCollector((CSharpCompilation)Context.SemanticModel.Compilation);
             foreach (var typeDeclaration in collectedTypes.Ordered.Dependencies)

--- a/Cecilifier.Core/AST/ConstructorDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/ConstructorDeclarationVisitor.cs
@@ -79,7 +79,7 @@ namespace Cecilifier.Core.AST
 
         protected override string GetSpecificModifiers()
         {
-            return string.Empty.AppendModifier(Constants.Cecil.CtorAttributes);
+            return Constants.Cecil.CtorAttributes;
         }
 
         internal void DefaultCtorInjector(string typeDefVar, ClassDeclarationSyntax declaringClass, bool isStatic)

--- a/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
@@ -26,7 +26,7 @@ namespace Cecilifier.Core.AST
             node.Accept(_memberCollector);
 
             var enumType = Context.Naming.Type(node);
-            var attrs = TypeModifiersToCecil(node);
+            var attrs = TypeModifiersToCecil(node, node.Modifiers);
             var enumSymbol = Context.SemanticModel.GetDeclaredSymbol(node).EnsureNotNull<ISymbol, ISymbol>($"Something really bad happened. Roslyn failed to resolve the symbol for the enum {node.Identifier.Text}");
             var typeDef = CecilDefinitionsFactory.Type(Context, enumType, enumSymbol.ContainingNamespace?.FullyQualifiedName(), enumSymbol.Name, enumSymbol.ContainingType?.Name, attrs + " | TypeAttributes.Sealed", Context.TypeResolver.Bcl.System.Enum, false, Array.Empty<string>());
             AddCecilExpressions(Context, typeDef);

--- a/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EnumDeclarationVisitor.cs
@@ -28,7 +28,7 @@ namespace Cecilifier.Core.AST
             var enumType = Context.Naming.Type(node);
             var attrs = TypeModifiersToCecil(node);
             var enumSymbol = Context.SemanticModel.GetDeclaredSymbol(node).EnsureNotNull<ISymbol, ISymbol>($"Something really bad happened. Roslyn failed to resolve the symbol for the enum {node.Identifier.Text}");
-            var typeDef = CecilDefinitionsFactory.Type(Context, enumType, node.Identifier.ValueText, enumSymbol.ContainingType?.Name, attrs + " | TypeAttributes.Sealed", Context.TypeResolver.Bcl.System.Enum, false, Array.Empty<string>());
+            var typeDef = CecilDefinitionsFactory.Type(Context, enumType, enumSymbol.ContainingNamespace?.FullyQualifiedName(), enumSymbol.Name, enumSymbol.ContainingType?.Name, attrs + " | TypeAttributes.Sealed", Context.TypeResolver.Bcl.System.Enum, false, Array.Empty<string>());
             AddCecilExpressions(Context, typeDef);
 
             

--- a/Cecilifier.Core/AST/EventDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/EventDeclarationVisitor.cs
@@ -131,7 +131,7 @@ namespace Cecilifier.Core.AST
         {
             var accessorModifiers = isInterfaceDef 
                 ? Constants.Cecil.InterfaceMethodAttributes 
-                : node.Modifiers.MethodModifiersToCecil((targetEnum, modifiers, defaultAccessibility) => ModifiersToCecil(modifiers, targetEnum, defaultAccessibility), "MethodAttributes.SpecialName");
+                : node.Modifiers.MethodModifiersToCecil("MethodAttributes.SpecialName");
 
             return accessorModifiers;
         }

--- a/Cecilifier.Core/AST/ExpressionVisitor.Stackalloc.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.Stackalloc.cs
@@ -123,7 +123,7 @@ partial class ExpressionVisitor
 
     private void EmitNewobjForSpanOfType(string resolvedSpanType)
     {
-        var spanInstanceType = $"{Utils.ImportFromMainModule("typeof(Span<>)")}.MakeGenericInstanceType({resolvedSpanType})";
+        var spanInstanceType = Context.TypeResolver.Resolve(Context.RoslynTypeSystem.SystemSpan).MakeGenericInstanceType(resolvedSpanType);
         var spanCtorVar = Context.Naming.SyntheticVariable("spanCtor", ElementKind.LocalVariable);
         AddCecilExpression($"var {spanCtorVar} = new MethodReference(\".ctor\", {Context.TypeResolver.Bcl.System.Void}, {spanInstanceType}) {{ HasThis = true }};");
         AddCecilExpression($"{spanCtorVar}.Parameters.Add({CecilDefinitionsFactory.Parameter("ptr", RefKind.None, Context.TypeResolver.Resolve("void*"))});");

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -703,6 +703,7 @@ namespace Cecilifier.Core.AST
         
         public override void VisitThrowExpression(ThrowExpressionSyntax node)
         {
+            using var _ = LineInformationTracker.Track(Context, node);
             CecilExpressionFactory.EmitThrow(Context, ilVar, node.Expression);
         }
         

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -1145,7 +1145,7 @@ namespace Cecilifier.Core.AST
         private void ProcessMethodCall(SimpleNameSyntax node, IMethodSymbol method)
         {
             // Local methods are always static.
-            if (method.MethodKind != MethodKind.LocalFunction && !method.IsStatic && method.IsDefinedInCurrentType(Context) && node.Parent.Kind() == SyntaxKind.InvocationExpression)
+            if (method.MethodKind != MethodKind.LocalFunction && !method.IsStatic && method.IsDefinedInCurrentAssembly(Context) && node.Parent.Kind() == SyntaxKind.InvocationExpression)
             {
                 Context.EmitCilInstruction(ilVar, OpCodes.Ldarg_0);
             }

--- a/Cecilifier.Core/AST/GlobalStatementHandler.cs
+++ b/Cecilifier.Core/AST/GlobalStatementHandler.cs
@@ -23,7 +23,8 @@ namespace Cecilifier.Core.AST
             typeVar = context.Naming.Type("topLevelStatements", ElementKind.Class);
             var typeExps = CecilDefinitionsFactory.Type(
                 context, 
-                typeVar, 
+                typeVar,
+                null, // global statements cannot be declared in namespace
                 "Program", 
                 null, // Top level type has no outer type.
                 typeModifiers, 

--- a/Cecilifier.Core/AST/IVisitorContext.cs
+++ b/Cecilifier.Core/AST/IVisitorContext.cs
@@ -14,8 +14,6 @@ namespace Cecilifier.Core.AST
     {
         INameStrategy Naming { get; }
         
-        string CurrentNamespace { get; set; }
-
         SemanticModel SemanticModel { get; }
 
         DefinitionVariableManager DefinitionVariables { get; }
@@ -50,4 +48,3 @@ namespace Cecilifier.Core.AST
 
     }
 }
-

--- a/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
@@ -131,7 +131,7 @@ namespace Cecilifier.Core.AST
                                             // for ctors we want to use the `methodName` (== .ctor) instead of the `simpleName` (== ctor) otherwise we may fail to find existing variables.
                                             methodSymbol.MethodKind == MethodKind.Constructor ? methodName : simpleName,
                                             methodName, 
-                                            modifiersTokens.MethodModifiersToCecil((targetEnum, modifiers, defaultAccessibility) => ModifiersToCecil(modifiers, targetEnum, defaultAccessibility), GetSpecificModifiers(), methodSymbol), 
+                                            modifiersTokens.MethodModifiersToCecil(GetSpecificModifiers(), methodSymbol), 
                                             methodSymbol.ReturnType, 
                                             refReturn, 
                                             parameters,

--- a/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
@@ -31,7 +31,6 @@ namespace Cecilifier.Core.AST
             
             // local functions are not first class citizens wrt variable naming... handle them as methods for now.
             var localFunctionVar = Context.Naming.SyntheticVariable(node.Identifier.Text, ElementKind.Method);
-            
             ProcessMethodDeclarationInternal(
                 node, 
                 methodSymbol.ContainingType.Name, 

--- a/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
@@ -210,8 +210,8 @@ namespace Cecilifier.Core.AST
             context.WriteNewLine();
             context.WriteComment($"Method : {methodName}");
 
+            TypeDeclarationVisitor.EnsureForwardedTypeDefinition(context, returnType, Array.Empty<TypeParameterSyntax>());
             var exps = CecilDefinitionsFactory.Method(context, methodVar, methodName, methodModifiers, returnType, refReturn, typeParameters);
-            
             foreach (var exp in exps)
             {
                 context.WriteCecilExpression(exp);

--- a/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
@@ -17,7 +17,7 @@ namespace Cecilifier.Core.AST
 {
     internal class PropertyDeclarationVisitor : SyntaxWalkerBase
     {
-        private static readonly List<ParamData> NoParameters = new List<ParamData>();
+        private static readonly List<ParamData> NoParameters = new();
         private string backingFieldVar;
 
         public PropertyDeclarationVisitor(IVisitorContext context) : base(context) { }

--- a/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
@@ -10,6 +10,7 @@ using Cecilifier.Core.Variables;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using static Cecilifier.Core.Misc.Utils;
 
@@ -114,8 +115,8 @@ namespace Cecilifier.Core.AST
         private void ProcessPropertyAccessors(BasePropertyDeclarationSyntax node, string propertyDeclaringTypeVar, string propName, string propertyType, string propDefVar, List<ParamData> parameters, ArrowExpressionClauseSyntax? arrowExpression)
         {
             using var _ = LineInformationTracker.Track(Context, node);
-            var propertySymbol = (IPropertySymbol) Context.SemanticModel.GetDeclaredSymbol(node);
-            var accessorModifiers = node.Modifiers.MethodModifiersToCecil((targetEnum, modifiers, defaultAccessibility) => ModifiersToCecil(modifiers, targetEnum, defaultAccessibility), "MethodAttributes.SpecialName", propertySymbol.GetMethod ?? propertySymbol.SetMethod);
+            var propertySymbol = Context.SemanticModel.GetDeclaredSymbol(node).EnsureNotNull<ISymbol, IPropertySymbol>();
+            var accessorModifiers = node.Modifiers.MethodModifiersToCecil("MethodAttributes.SpecialName", propertySymbol.GetMethod ?? propertySymbol.SetMethod);
 
             var declaringType = node.ResolveDeclaringType<TypeDeclarationSyntax>();
             if (arrowExpression != null)
@@ -135,7 +136,7 @@ namespace Cecilifier.Core.AST
 
                     case SyntaxKind.InitKeyword:
                         Context.WriteComment(" Init");
-                        var setterReturnType = $"new RequiredModifierType({ImportExpressionForType(typeof(IsExternalInit))}, {Context.TypeResolver.Bcl.System.Void})";
+                        var setterReturnType = $"new RequiredModifierType({Context.TypeResolver.Resolve(typeof(IsExternalInit).FullName)}, {Context.TypeResolver.Bcl.System.Void})";
                         AddSetterMethod(setterReturnType, accessor);
                         break;
                     
@@ -154,13 +155,14 @@ namespace Cecilifier.Core.AST
                     return;
 
                 backingFieldVar = Context.Naming.FieldDeclaration(node);
-                var modifiers = ModifiersToCecil(accessor.Modifiers, "FieldAttributes", "Private");
-                if (hasInitProperty) 
-                    modifiers = modifiers.AppendModifier("FieldAttributes.InitOnly");
+                var m = accessor.Modifiers;
+                if (hasInitProperty)
+                    m = m.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
 
                 if (propertySymbol.IsStatic)
-                    modifiers = modifiers.AppendModifier("FieldAttributes.Static");
+                    m = m.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
                 
+                var modifiers = ModifiersToCecil<FieldAttributes>(m, "Private", FieldDeclarationVisitor.MapFieldAttributesFor);
                 var backingFieldExps = CecilDefinitionsFactory.Field(Context, propertySymbol.ContainingSymbol.ToDisplayString() , propertyDeclaringTypeVar, backingFieldVar, Utils.BackingFieldNameForAutoProperty(propName), propertyType, modifiers);
                 AddCecilExpressions(Context, backingFieldExps);
             }

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -313,7 +313,7 @@ namespace Cecilifier.Core.AST
 
             mapAttribute ??= MapAttributeForMembers;
             
-            var modifierStr = finalModifierList.Where(ExcludeHasNoCILRepresentation).SelectMany(mapAttribute).Aggregate("", (acc, curr) => (acc.Length > 0 ? $"{acc} | " : "") + $"{targetEnum}." + curr) + accessibilityModifiers;
+            var modifierStr = finalModifierList.Where(ExcludeModifiersWithNoCILRepresentation).SelectMany(mapAttribute).Aggregate("", (acc, curr) => (acc.Length > 0 ? $"{acc} | " : "") + $"{targetEnum}." + curr) + accessibilityModifiers;
             
             if(!modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword) || m.IsKind(SyntaxKind.InternalKeyword) || m.IsKind(SyntaxKind.PrivateKeyword) || m.IsKind(SyntaxKind.PublicKeyword) || m.IsKind(SyntaxKind.ProtectedKeyword)))
                 return modifierStr.AppendModifier($"{targetEnum}.{defaultAccessibility}");
@@ -380,13 +380,14 @@ namespace Cecilifier.Core.AST
             context.WriteNewLine();
         }
 
-        private static bool ExcludeHasNoCILRepresentation(SyntaxToken token)
+        private static bool ExcludeModifiersWithNoCILRepresentation(SyntaxToken token)
         {
             return !token.IsKind(SyntaxKind.PartialKeyword) 
                    && !token.IsKind(SyntaxKind.VolatileKeyword) 
                    && !token.IsKind(SyntaxKind.UnsafeKeyword)
                    && !token.IsKind(SyntaxKind.AsyncKeyword)
-                   && !token.IsKind(SyntaxKind.ExternKeyword);
+                   && !token.IsKind(SyntaxKind.ExternKeyword)
+                   && !token.IsKind(SyntaxKind.ReadOnlyKeyword);
         }
 
         protected string ResolveExpressionType(ExpressionSyntax expression)

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -48,7 +48,7 @@ namespace Cecilifier.Core.AST
 
         protected void AddMethodCall(string ilVar, IMethodSymbol method, bool isAccessOnThisOrObjectCreation = false)
         {
-            var opCode = (method.IsStatic || method.IsDefinedInCurrentType(Context) && isAccessOnThisOrObjectCreation || method.ContainingType.IsValueType) && !(method.IsVirtual || method.IsAbstract || method.IsOverride)
+            var opCode = (method.IsStatic || method.IsDefinedInCurrentAssembly(Context) && isAccessOnThisOrObjectCreation || method.ContainingType.IsValueType) && !(method.IsVirtual || method.IsAbstract || method.IsOverride)
                 ? OpCodes.Call
                 : OpCodes.Callvirt;
             
@@ -57,7 +57,7 @@ namespace Cecilifier.Core.AST
                 opCode = OpCodes.Call;
             }
             
-            if (method.IsGenericMethod && method.IsDefinedInCurrentType(Context))
+            if (method.IsGenericMethod && method.IsDefinedInCurrentAssembly(Context))
             {
                 // if the method in question is a generic method and it is defined in the same assembly create a generic instance
                 var resolvedMethodVar = Context.Naming.MemberReference(method.Name);
@@ -857,7 +857,7 @@ namespace Cecilifier.Core.AST
          */
         protected static void EnsureForwardedMethod(IVisitorContext context, string methodDeclarationVar, IMethodSymbol method, TypeParameterSyntax[] typeParameters)
         {
-            if (!method.IsDefinedInCurrentType(context))
+            if (!method.IsDefinedInCurrentAssembly(context))
                 return;
 
             var found = context.DefinitionVariables.GetMethodVariable(method.AsMethodDefinitionVariable());

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -90,7 +90,7 @@ namespace Cecilifier.Core.AST
 
         protected void AddCilInstruction(string ilVar, OpCode opCode, ITypeSymbol type)
         {
-            string operand = Context.TypeResolver.Resolve(type);
+            var operand = Context.TypeResolver.Resolve(type);
             Context.EmitCilInstruction(ilVar, opCode, operand);
         }
 

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -137,7 +137,7 @@ namespace Cecilifier.Core.AST
 
             return AddLocalVariableWithResolvedType(localVarName, currentMethod, varType);
         }
-        
+
         protected void LoadLiteralValue(string ilVar, ITypeSymbol type, string value, bool isTargetOfCall)
         {
             switch (type.SpecialType)
@@ -157,7 +157,7 @@ namespace Cecilifier.Core.AST
                     if (value == null)
                         Context.EmitCilInstruction(ilVar, OpCodes.Ldnull);
                     else
-                        Context.EmitCilInstruction(ilVar, OpCodes.Ldstr, value);
+                        Context.EmitCilInstruction(ilVar, OpCodes.Ldstr, SymbolDisplay.FormatLiteral(value, true));
                     break;
 
                 case SpecialType.System_Char:

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
@@ -25,6 +25,7 @@ internal partial class TypeDeclarationVisitor
         var typeDef = CecilDefinitionsFactory.Type(
             Context,
             typeVar,
+            delegateSymbol.ContainingNamespace?.FullyQualifiedName() ?? string.Empty,
             node.Identifier.ValueText,
             delegateSymbol.ContainingType?.Name,
             CecilDefinitionsFactory.DefaultTypeAttributeFor(node.Kind(), false).AppendModifier(accessibility),

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
@@ -19,7 +19,7 @@ internal partial class TypeDeclarationVisitor
         Context.WriteNewLine();
         Context.WriteComment($"Delegate: {node.Identifier.Text}");
         var typeVar = Context.Naming.Delegate(node);
-        var accessibility = ModifiersToCecil(node.Modifiers, "TypeAttributes", "Private");
+        var accessibility = TypeModifiersToCecil(node, node.Modifiers);
 
         var delegateSymbol = Context.SemanticModel.GetDeclaredSymbol(node).EnsureNotNull();
         var typeDef = CecilDefinitionsFactory.Type(

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
@@ -50,7 +50,7 @@ namespace Cecilifier.Core.AST
             using (Context.DefinitionVariables.WithCurrent(structSymbol.ContainingSymbol.FullyQualifiedName(), node.Identifier.ValueText, VariableMemberKind.Type, definitionVar))
             {
                 HandleTypeDeclaration(node, definitionVar);
-                ProcessStructPseudoAttributes(node, definitionVar, structSymbol);
+                ProcessStructPseudoAttributes(definitionVar, structSymbol);
                 base.VisitStructDeclaration(node);
                 EnsureCurrentTypeHasADefaultCtor(node, definitionVar);
             }
@@ -124,7 +124,7 @@ namespace Cecilifier.Core.AST
             var found = Context.DefinitionVariables.GetVariable(typeSymbol.Name, VariableMemberKind.Type, typeSymbol.ContainingType?.Name);
             if (!found.IsValid || !found.IsForwarded)
             {
-                AddTypeDefinition(Context, varName, typeSymbol, TypeModifiersToCecil(node), node.TypeParameterList?.Parameters, node.CollectOuterTypeArguments());
+                AddTypeDefinition(Context, varName, typeSymbol, TypeModifiersToCecil(node, node.Modifiers), node.TypeParameterList?.Parameters, node.CollectOuterTypeArguments());
             }
 
             if (typeSymbol.BaseType?.IsGenericType == true)
@@ -155,7 +155,7 @@ namespace Cecilifier.Core.AST
             
             var typeDeclaration =  (BaseTypeDeclarationSyntax) typeSymbol.DeclaringSyntaxReferences.First().GetSyntax();
             var typeDeclarationVar = context.Naming.Type(typeSymbol.Name, typeSymbol.TypeKind.ToElementKind());
-            AddTypeDefinition(context, typeDeclarationVar, typeSymbol, TypeModifiersToCecil(typeDeclaration), typeParameters, Array.Empty<TypeParameterSyntax>());
+            AddTypeDefinition(context, typeDeclarationVar, typeSymbol, TypeModifiersToCecil(typeDeclaration, typeDeclaration.Modifiers), typeParameters, Array.Empty<TypeParameterSyntax>());
             
             var v = context.DefinitionVariables.RegisterNonMethod(typeSymbol.ContainingSymbol?.FullyQualifiedName(), typeSymbol.Name, VariableMemberKind.Type, typeDeclarationVar);
             v.IsForwarded = true;
@@ -211,8 +211,11 @@ processGenerics:
             node.Accept(new DefaultCtorVisitor(Context, typeLocalVar));
         }
         
-        private void ProcessStructPseudoAttributes(StructDeclarationSyntax node, string structDefinitionVar, INamedTypeSymbol structSymbol)
+        private void ProcessStructPseudoAttributes(string structDefinitionVar, INamedTypeSymbol structSymbol)
         {
+            if (!structSymbol.IsReadOnly)
+                return;
+            
             var isReadOnlyAttributeCtor = Context.RoslynTypeSystem.SystemRuntimeCompilerServices
                 ?.GetMembers(".ctor")
                 .OfType<IMethodSymbol>()

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.cs
@@ -165,6 +165,7 @@ namespace Cecilifier.Core.AST
             var typeDefinitionExp = CecilDefinitionsFactory.Type(
                 context, 
                 typeDeclarationVar,
+                typeSymbol.ContainingNamespace?.FullyQualifiedName() ?? string.Empty,
                 typeSymbol.Name, 
                 typeModifiers,
                 baseType,

--- a/Cecilifier.Core/Cecilifier.Core.csproj
+++ b/Cecilifier.Core/Cecilifier.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.60.0</AssemblyVersion>
+    <AssemblyVersion>1.70.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/Cecilifier.Core/Cecilifier.Core.csproj
+++ b/Cecilifier.Core/Cecilifier.Core.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-4.final" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>
 

--- a/Cecilifier.Core/Cecilifier.cs
+++ b/Cecilifier.Core/Cecilifier.cs
@@ -17,7 +17,9 @@ namespace Cecilifier.Core
     public sealed class Cecilifier
     {
         internal const int CecilifierProgramPreambleLength = 18; // The # of lines before the 1st cecilified line of code (see CecilifierExtensions.AsCecilApplication())
-        
+
+        public static readonly int SupportedCSharpVersion = int.Parse(LanguageVersion.CSharp10.ToString().Substring("CSharp".Length));
+            
         public static CecilifierResult Process(Stream content, CecilifierOptions options)
         {
             UsageVisitor.ResetInstance();

--- a/Cecilifier.Core/Cecilifier.cs
+++ b/Cecilifier.Core/Cecilifier.cs
@@ -24,7 +24,7 @@ namespace Cecilifier.Core
         {
             UsageVisitor.ResetInstance();
             using var stream = new StreamReader(content);
-            var syntaxTree = CSharpSyntaxTree.ParseText(stream.ReadToEnd(), new CSharpParseOptions(LanguageVersion.CSharp10));
+            var syntaxTree = CSharpSyntaxTree.ParseText(stream.ReadToEnd(), new CSharpParseOptions(LanguageVersion.CSharp11));
             var metadataReferences = options.References.Select(refPath => MetadataReference.CreateFromFile(refPath)).ToArray();
 
             var comp = CSharpCompilation.Create(

--- a/Cecilifier.Core/Extensions/CecilifierExtensions.cs
+++ b/Cecilifier.Core/Extensions/CecilifierExtensions.cs
@@ -46,6 +46,22 @@ namespace Cecilifier.Core.Extensions
 
             return $"{to} | {modifier}";
         }
+        
+        public static StringBuilder AppendModifier(this StringBuilder to, string modifier)
+        {
+            if (string.IsNullOrWhiteSpace(modifier))
+            {
+                return to;
+            }
+
+            if (to.Length != 0)
+            {
+                to.Append(" | ");
+            }
+
+            to.Append(modifier);
+            return to;
+        }
 
         public static string AsCecilApplication(this string cecilSnippet, string assemblyName, string entryPointVar = null)
         {

--- a/Cecilifier.Core/Extensions/FieldExtensions.cs
+++ b/Cecilifier.Core/Extensions/FieldExtensions.cs
@@ -10,7 +10,7 @@ namespace Cecilifier.Core.Extensions
     {
         public static string FieldResolverExpression(this IFieldSymbol field, IVisitorContext context)
         {
-            if (field.IsDefinedInCurrentType(context))
+            if (field.IsDefinedInCurrentAssembly(context))
             {
                 var found = context.DefinitionVariables.GetVariable(field.Name, VariableMemberKind.Field, field.ContainingType.ToDisplayString());
                 if (!found.IsValid)

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -50,7 +50,7 @@ namespace Cecilifier.Core.Extensions
             ILocalSymbol local => local.Type,
             _ => throw new NotSupportedException($"({symbol.Kind}) symbol {symbol.ToDisplayString()} is not supported.")
         };
-        
+
         private static ITypeSymbol GetElementType(this ISymbol symbol) => symbol switch
         {
             IPointerTypeSymbol pointer => pointer.PointedAtType.GetElementType(),

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -61,7 +61,7 @@ namespace Cecilifier.Core.Extensions
             _ => (ITypeSymbol) symbol
         };
 
-        public static bool IsDefinedInCurrentType<T>(this T method, IVisitorContext ctx) where T : ISymbol
+        public static bool IsDefinedInCurrentAssembly<T>(this T method, IVisitorContext ctx) where T : ISymbol
         {
             return SymbolEqualityComparer.Default.Equals(method.ContainingAssembly, ctx.SemanticModel.Compilation.Assembly);
         }

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -159,7 +159,6 @@ namespace Cecilifier.Core.Extensions
             var value = symbol.ExplicitDefaultValue?.ToString();
             return symbol.Type.SpecialType switch
             {
-                SpecialType.System_String => value != null ? $"\"{value}\"" : null,
                 SpecialType.System_Single => $"{value}f",
                 _ => value
             };

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Cecilifier.Core.AST;
 using Cecilifier.Core.Misc;
+using Cecilifier.Core.Naming;
 using Cecilifier.Core.Variables;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -17,6 +18,19 @@ namespace Cecilifier.Core.Extensions
     {
         private static readonly SymbolDisplayFormat FullyQualifiedDisplayFormat = new(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
+        public static ElementKind ToElementKind(this TypeKind self) => self switch
+        {
+            TypeKind.Class => ElementKind.Class,
+            TypeKind.Enum => ElementKind.Enum,
+            TypeKind.Struct => ElementKind.Struct,
+            TypeKind.Interface => ElementKind.Interface,
+            TypeKind.Delegate => ElementKind.Delegate,
+            TypeKind.Array => ElementKind.None,
+            TypeKind.TypeParameter => ElementKind.None,
+            
+            _ => throw new NotImplementedException($"TypeKind `{self}` is not supported.") 
+        };
+        
         public static string FullyQualifiedName(this ISymbol type)
         {
             return type.ToDisplayString(FullyQualifiedDisplayFormat);

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -45,6 +45,13 @@ namespace Cecilifier.Core.Extensions
 
         public static string AssemblyQualifiedName(this ISymbol type)
         {
+            // ISymbol.ToDisplayString() does not have the option to use the metadata name for IntPtr
+            // returning `nint` instead.
+            if (type is ITypeSymbol { SpecialType: SpecialType.System_IntPtr } ts)
+            {
+                return "System.IntPtr";
+            }
+            
             var format = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
             var namespaceQualifiedName = type.ToDisplayString(format);
             var elementType = type.GetElementType();

--- a/Cecilifier.Core/Extensions/MethodExtensions.cs
+++ b/Cecilifier.Core/Extensions/MethodExtensions.cs
@@ -34,7 +34,7 @@ namespace Cecilifier.Core.Extensions
 
         public static string MethodResolverExpression(this IMethodSymbol method, IVisitorContext ctx)
         {
-            if (method.IsDefinedInCurrentType(ctx))
+            if (method.IsDefinedInCurrentAssembly(ctx))
             {
                 var tbf = method.AsMethodDefinitionVariable();
                 var found = ctx.DefinitionVariables.GetMethodVariable(tbf);

--- a/Cecilifier.Core/Extensions/MethodExtensions.cs
+++ b/Cecilifier.Core/Extensions/MethodExtensions.cs
@@ -9,6 +9,7 @@ using Cecilifier.Core.Variables;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using static Cecilifier.Core.Misc.Utils;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace Cecilifier.Core.Extensions
 {
@@ -78,7 +79,7 @@ namespace Cecilifier.Core.Extensions
                 variableName);
         }
 
-        public static string MethodModifiersToCecil(this SyntaxTokenList modifiers, Func<string, IReadOnlyList<SyntaxToken>, string, string> modifiersToCecil, string specificModifiers = null, IMethodSymbol methodSymbol = null)
+        public static string MethodModifiersToCecil(this SyntaxTokenList modifiers, string specificModifiers = null, IMethodSymbol methodSymbol = null)
         {
             var modifiersStr = MapExplicitModifiers(modifiers);
 
@@ -103,19 +104,18 @@ namespace Cecilifier.Core.Extensions
 
             var validModifiers = RemoveSourceModifiersWithNoILEquivalent(modifiers);
 
-            var cecilModifiersStr = modifiersToCecil("MethodAttributes", validModifiers.ToList(), defaultAccessibility);
-
+            var cecilModifiersStr = new StringBuilder(SyntaxWalkerBase.ModifiersToCecil<MethodAttributes>(validModifiers.ToList(), defaultAccessibility, MapMethodAttributeFor));
             if (specificModifiers != null)
             {
-                cecilModifiersStr = cecilModifiersStr.AppendModifier(specificModifiers);
+                cecilModifiersStr.AppendModifier(specificModifiers);
             }
 
-            cecilModifiersStr = cecilModifiersStr.AppendModifier("MethodAttributes.HideBySig").AppendModifier(modifiersStr);
+            cecilModifiersStr.AppendModifier("MethodAttributes.HideBySig").AppendModifier(modifiersStr);
             if (methodSymbol.HasCovariantReturnType())
             {
-                cecilModifiersStr = cecilModifiersStr.AppendModifier("MethodAttributes.NewSlot");
+                cecilModifiersStr.AppendModifier("MethodAttributes.NewSlot");
             }
-            return cecilModifiersStr;
+            return cecilModifiersStr.ToString();
         }
 
         public static bool HasCovariantReturnType(this IMethodSymbol method) => method != null && method.IsOverride && !method.ReturnType.Equals(method.OverriddenMethod.ReturnType);
@@ -151,5 +151,25 @@ namespace Cecilifier.Core.Extensions
                        && !mod.IsKind(SyntaxKind.SealedKeyword)
                        && !mod.IsKind(SyntaxKind.UnsafeKeyword));
         }
+
+        private static IEnumerable<string> MapMethodAttributeFor(SyntaxToken token) =>
+            token.Kind() switch
+            {
+                SyntaxKind.InternalKeyword => new[] { "Assembly" },
+                SyntaxKind.ProtectedKeyword => new[] { "Family" },
+                SyntaxKind.PrivateKeyword => new[] { "Private" },
+                SyntaxKind.PublicKeyword => new[] { "Public" },
+                SyntaxKind.StaticKeyword => new[] { "Static" },
+                SyntaxKind.AbstractKeyword => new[] { "Abstract" },
+               
+                SyntaxKind.AsyncKeyword => Array.Empty<string>(),
+                SyntaxKind.UnsafeKeyword => Array.Empty<string>(),
+                SyntaxKind.PartialKeyword => Array.Empty<string>(),
+                SyntaxKind.VolatileKeyword => Array.Empty<string>(),
+                SyntaxKind.ExternKeyword => Array.Empty<string>(),
+                SyntaxKind.ConstKeyword => Array.Empty<string>(),
+                SyntaxKind.ReadOnlyKeyword => Array.Empty<string>(),
+                _ => throw new ArgumentException($"Unsupported attribute name: {token.Kind().ToString()}")
+            };
     }
 }

--- a/Cecilifier.Core/Extensions/TypeExtensions.cs
+++ b/Cecilifier.Core/Extensions/TypeExtensions.cs
@@ -25,9 +25,14 @@ namespace Cecilifier.Core.Extensions
         {
             return $"{type}.MakeByReferenceType()";
         }
+        public static string MakeGenericInstanceType(this string type, IEnumerable<string> genericTypes)
+        {
+            return $"{type}.MakeGenericInstanceType({string.Join(", ", genericTypes)})";
+        }
+        
         public static string MakeGenericInstanceType(this string type, string genericType)
         {
-            return $"{type}.MakeGenericInstanceType<{genericType}>()";
+            return $"{type}.MakeGenericInstanceType({genericType})";
         }
 
         public static bool IsPrimitiveType(this ITypeSymbol type) => type.SpecialType switch {

--- a/Cecilifier.Core/Extensions/TypeSyntaxExtensions.cs
+++ b/Cecilifier.Core/Extensions/TypeSyntaxExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.Extensions;
+
+internal static class TypesExtensions
+{
+    public static string NameFrom(this TypeSyntax type)
+    {
+        return type switch
+        {
+            ArrayTypeSyntax arrayTypeSyntax => NameFrom(arrayTypeSyntax.ElementType),
+            AliasQualifiedNameSyntax aliasQualifiedNameSyntax => throw new NotImplementedException(),
+            FunctionPointerTypeSyntax functionPointerTypeSyntax => functionPointerTypeSyntax.ToString(),
+            GenericNameSyntax genericNameSyntax => genericNameSyntax.Identifier.Text,
+            IdentifierNameSyntax identifierNameSyntax => identifierNameSyntax.Identifier.Text,
+            QualifiedNameSyntax qualifiedNameSyntax => qualifiedNameSyntax.ToString(),
+            SimpleNameSyntax simpleNameSyntax => simpleNameSyntax.Identifier.Text,
+            NullableTypeSyntax nullableTypeSyntax => NameFrom(nullableTypeSyntax.ElementType),
+            OmittedTypeArgumentSyntax omittedTypeArgumentSyntax => throw new NotImplementedException(),
+            PointerTypeSyntax pointerTypeSyntax => NameFrom(pointerTypeSyntax.ElementType),
+            PredefinedTypeSyntax predefinedTypeSyntax => predefinedTypeSyntax.Keyword.Text,
+            RefTypeSyntax refTypeSyntax => NameFrom(refTypeSyntax.Type),
+            TupleTypeSyntax tupleTypeSyntax => tupleTypeSyntax.ToString(),
+            
+            NameSyntax nameSyntax => throw new InvalidOperationException($"Unexpected name syntax: {nameSyntax}"),
+        };
+    }
+
+    public static string NameFrom(this BaseTypeDeclarationSyntax typeDeclaration)
+    {
+        var sb = new StringBuilder();
+        var parent = typeDeclaration.Parent;
+        while (parent != null && parent is NamespaceDeclarationSyntax namespaceDeclaration)
+        {
+            sb.AppendFormat(namespaceDeclaration.Name.ToString());
+            sb.Append('.');
+
+            parent = parent.Parent;
+        }
+
+        sb.Append(typeDeclaration.Identifier.Text);
+
+        return sb.ToString();
+    }
+}

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -78,9 +78,10 @@ namespace Cecilifier.Core.Misc
          */
         public static IEnumerable<string> Type(
             IVisitorContext context, 
-            string typeVar, 
-            string typeName, 
-            string attrs, 
+            string typeVar,
+            string typeNamespace,
+            string typeName,
+            string attrs,
             string baseTypeName, 
             string outerTypeName, 
             bool isStructWithNoFields, 
@@ -96,7 +97,7 @@ namespace Cecilifier.Core.Misc
             }
             
             var exps = new List<string>();
-            var typeDefExp = $"var {typeVar} = new TypeDefinition(\"{context.CurrentNamespace}\", \"{typeName}\", {attrs}{(!string.IsNullOrWhiteSpace(baseTypeName) ? ", " + baseTypeName : "")})";
+            var typeDefExp = $"var {typeVar} = new TypeDefinition(\"{typeNamespace}\", \"{typeName}\", {attrs}{(!string.IsNullOrWhiteSpace(baseTypeName) ? ", " + baseTypeName : "")})";
             if (properties.Length > 0)
             {
                 exps.Add($"{typeDefExp} {{ {string.Join(',', properties)} }};");
@@ -129,11 +130,12 @@ namespace Cecilifier.Core.Misc
             return exps;
         }
         
-        public static IEnumerable<string> Type(IVisitorContext context, string typeVar, string typeName, string outerTypeName,string attrs, string baseTypeName, bool isStructWithNoFields, IEnumerable<string> interfaces, TypeParameterListSyntax typeParameters = null, params string[] properties)
+        public static IEnumerable<string> Type(IVisitorContext context, string typeVar, string typeNamespace, string typeName, string outerTypeName,string attrs, string baseTypeName, bool isStructWithNoFields, IEnumerable<string> interfaces, TypeParameterListSyntax typeParameters = null, params string[] properties)
         {
             return Type(
                 context,
                 typeVar,
+                typeNamespace,
                 typeName,
                 attrs,
                 baseTypeName,

--- a/Cecilifier.Core/Misc/CecilifierContext.cs
+++ b/Cecilifier.Core/Misc/CecilifierContext.cs
@@ -51,8 +51,6 @@ namespace Cecilifier.Core.Misc
 
         public DefinitionVariableManager DefinitionVariables { get; }
 
-        public string CurrentNamespace { get; set; }
-
         public LinkedListNode<string> CurrentLine => output.Last;
 
         public int CecilifiedLineNumber { get; private set; }

--- a/Cecilifier.Core/Misc/MiscRoslynExtensions.cs
+++ b/Cecilifier.Core/Misc/MiscRoslynExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Cecilifier.Core.Misc;
 
@@ -9,5 +10,14 @@ public static class MiscRoslynExtensions
         RefKind.Out => Constants.ParameterAttributes.Out,
         RefKind.In => Constants.ParameterAttributes.In,
         _ => string.Empty,
+    };
+
+    public static SyntaxKind MapCompoundAssignment(this SyntaxKind toBeMapped) => toBeMapped switch
+    {
+        SyntaxKind.AddAssignmentExpression => SyntaxKind.PlusToken,
+        SyntaxKind.SubtractAssignmentExpression => SyntaxKind.MinusToken,
+        SyntaxKind.MultiplyAssignmentExpression  => SyntaxKind.AsteriskToken,
+        SyntaxKind.DivideAssignmentExpression  => SyntaxKind.SlashToken,
+        _ => SyntaxKind.None
     };
 }

--- a/Cecilifier.Core/Misc/StaticDelegateCacheContext.cs
+++ b/Cecilifier.Core/Misc/StaticDelegateCacheContext.cs
@@ -15,6 +15,7 @@ public struct StaticDelegateCacheContext
     public bool IsStaticDelegate { get; init; }
 
     private string DeclaringTypeName => Method.ContainingType.Name;
+    private string DeclaringTypeNamespace => Method.ContainingType.ContainingNamespace?.FullyQualifiedName() ?? Method.ContainingNamespace?.FullyQualifiedName() ?? string.Empty;  
         
     /// <summary>
     /// Ensures that there's a static field declared inside an inner type of the current type being processed
@@ -82,6 +83,7 @@ public struct StaticDelegateCacheContext
         var cacheTypeExps = CecilDefinitionsFactory.Type(
             context,
             cachedTypeVar,
+            DeclaringTypeNamespace,
             cacheTypeName,
             DeclaringTypeName,
             Constants.Cecil.StaticClassAttributes.AppendModifier("TypeAttributes.NestedPrivate"),

--- a/Cecilifier.Core/Misc/TypeResolverImpl.cs
+++ b/Cecilifier.Core/Misc/TypeResolverImpl.cs
@@ -52,7 +52,7 @@ namespace Cecilifier.Core.Misc
             {
                 return null;
             }
-
+            
             return ResolvePredefinedType(type);
         }
 
@@ -69,7 +69,9 @@ namespace Cecilifier.Core.Misc
             }
             
             var genericType = Resolve(OpenGenericTypeName(genericTypeSymbol.ConstructedFrom));
-            return MakeGenericInstanceType(genericType, genericTypeSymbol);
+            return genericTypeSymbol.IsDefinition 
+                ? genericType 
+                : MakeGenericInstanceType(genericType, genericTypeSymbol);
         }
 
         public string ResolveLocalVariableType(ITypeSymbol type)
@@ -100,9 +102,8 @@ namespace Cecilifier.Core.Misc
         private string MakeGenericInstanceType(string typeReference, INamedTypeSymbol genericTypeSymbol)
         {
             var typeArgs = CollectTypeArguments(genericTypeSymbol, new List<string>());
-            //TODO: REFACTOR : Call TypeExtensions.MakeGenericInstanceType() instead.
             return typeArgs.Count > 0
-                ? $"{typeReference}.MakeGenericInstanceType({string.Join(",", typeArgs)})"
+                ? typeReference.MakeGenericInstanceType(typeArgs)
                 : typeReference;
         }
 

--- a/Cecilifier.Core/Misc/TypeResolverImpl.cs
+++ b/Cecilifier.Core/Misc/TypeResolverImpl.cs
@@ -100,6 +100,7 @@ namespace Cecilifier.Core.Misc
         private string MakeGenericInstanceType(string typeReference, INamedTypeSymbol genericTypeSymbol)
         {
             var typeArgs = CollectTypeArguments(genericTypeSymbol, new List<string>());
+            //TODO: REFACTOR : Call TypeExtensions.MakeGenericInstanceType() instead.
             return typeArgs.Count > 0
                 ? $"{typeReference}.MakeGenericInstanceType({string.Join(",", typeArgs)})"
                 : typeReference;

--- a/Cecilifier.Core/Misc/Utils.cs
+++ b/Cecilifier.Core/Misc/Utils.cs
@@ -16,7 +16,7 @@ namespace Cecilifier.Core.Misc
 
         public static string MakeGenericTypeIfAppropriate(IVisitorContext context, ISymbol memberSymbol, string backingFieldVar, string memberDeclaringTypeVar)
         {
-            if (!(memberSymbol.ContainingSymbol is INamedTypeSymbol ts) || !ts.IsGenericType || !memberSymbol.IsDefinedInCurrentType(context))
+            if (!(memberSymbol.ContainingSymbol is INamedTypeSymbol ts) || !ts.IsGenericType || !memberSymbol.IsDefinedInCurrentAssembly(context))
                 return backingFieldVar;
 
             //TODO: Register the following variable?

--- a/Cecilifier.Core/Naming/DefaultNameStrategy.cs
+++ b/Cecilifier.Core/Naming/DefaultNameStrategy.cs
@@ -30,6 +30,7 @@ namespace Cecilifier.Core.Naming
             [ElementKind.GenericInstance] = "gi",
             [ElementKind.MemberReference] = "r",
             [ElementKind.IL] = "il",
+            [ElementKind.None] = string.Empty,
         };
 
         private readonly IReadOnlyDictionary<ElementKind, string> _format;

--- a/Cecilifier.Core/Naming/ElementKind.cs
+++ b/Cecilifier.Core/Naming/ElementKind.cs
@@ -21,6 +21,7 @@ namespace Cecilifier.Core.Naming
         Attribute,
         IL,
         GenericParameter,
-        GenericInstance
+        GenericInstance,
+        None
     }
 }

--- a/Cecilifier.Core/TypeDependency/DependencyComparer.cs
+++ b/Cecilifier.Core/TypeDependency/DependencyComparer.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cecilifier.Core.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.TypeDependency;
+
+internal class DependencyComparer : IComparer<BaseTypeDeclarationSyntax>
+{
+    private readonly IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> dependencies;
+    private readonly IReadOnlyList<string> namespacesInScope;
+
+    public DependencyComparer(IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> dependencies, IReadOnlyList<string> namespacesInScope)
+    {
+        this.dependencies = dependencies;
+        this.namespacesInScope = namespacesInScope;
+    }
+
+    /// <summary>
+    /// Given i) a map of a type to all types it depends on and ii) a list of namespace in scope when the dependencies from i were collectd,
+    /// compares to *type declarations* (A,B) to determine the order in which those need to be processed to minimize *forward* referencing,
+    /// i.e, referencing a type before its definition has been processed. 
+    /// </summary>
+    /// <returns>
+    /// 0 if the types do not depend on each other if there's a cyclic dependency
+    /// 1 if A depends on B, i.e, A >  B
+    /// -1 if B depends on A, i.e, B > A  
+    /// </returns>
+    public int Compare(BaseTypeDeclarationSyntax x, BaseTypeDeclarationSyntax y)
+    {
+        var xDependsOnY = dependencies[x].Any(t => t.NameFrom() == y.NameFrom() || namespacesInScope.Any(ns => $"{ns}.{t.NameFrom()}" == y.NameFrom()));
+        var yDependsOnX = dependencies[y].Any(t => t.NameFrom() == x.NameFrom()|| namespacesInScope.Any(ns => $"{ns}.{t.NameFrom()}" == x.NameFrom()));
+        
+        if (xDependsOnY && !yDependsOnX)
+            return 1; // x depends on y so y needs to appear first, i.e, x > y
+        
+        if (yDependsOnX && !xDependsOnY)
+            return -1; // y depends on x so x needs to appear first, i.e, x < y
+
+        if (xDependsOnY && yDependsOnX)
+            return 0;
+        
+        return 0;
+    }
+}

--- a/Cecilifier.Core/TypeDependency/DependencyComparer.cs
+++ b/Cecilifier.Core/TypeDependency/DependencyComparer.cs
@@ -33,7 +33,7 @@ internal class DependencyComparer : IComparer<BaseTypeDeclarationSyntax>
     public int Compare(BaseTypeDeclarationSyntax x, BaseTypeDeclarationSyntax y)
     {
         var numberOfReferencesFromXToY = dependencies[x].Where(t => t.Key == y.NameFrom() || namespacesInScope.Any(ns => $"{ns}.{t.Key}" == y.NameFrom())).Select(p => p.Value).SingleOrDefault();
-        var numberOfReferencesFromYToX = dependencies[y].Where(t => t.Key == x.NameFrom()|| namespacesInScope.Any(ns => $"{ns}.{t.Key}" == x.NameFrom())).Select(p => p.Value).SingleOrDefault();
+        var numberOfReferencesFromYToX = dependencies[y].Where(t => t.Key == x.NameFrom() || namespacesInScope.Any(ns => $"{ns}.{t.Key}" == x.NameFrom())).Select(p => p.Value).SingleOrDefault();
         
         return numberOfReferencesFromXToY - numberOfReferencesFromYToX;
     }

--- a/Cecilifier.Core/TypeDependency/DependencyComparer.cs
+++ b/Cecilifier.Core/TypeDependency/DependencyComparer.cs
@@ -22,12 +22,14 @@ internal class DependencyComparer : IComparer<BaseTypeDeclarationSyntax>
     /// i.e, referencing a type before its definition has been processed. 
     /// </summary>
     /// <returns>
-    /// 0 if the types do not depend on each other if there's a cyclic dependency
+    /// 0 if the types do not depend on each other or if there's a cyclic dependency
     /// 1 if A depends on B, i.e, A >  B
     /// -1 if B depends on A, i.e, B > A  
     /// </returns>
     public int Compare(BaseTypeDeclarationSyntax x, BaseTypeDeclarationSyntax y)
     {
+        // TODO: take the number of `dependencies` into account when sorting; i.e, more dependencies => >
+        //       this may break tests; that may be ok.
         var xDependsOnY = dependencies[x].Any(t => t.NameFrom() == y.NameFrom() || namespacesInScope.Any(ns => $"{ns}.{t.NameFrom()}" == y.NameFrom()));
         var yDependsOnX = dependencies[y].Any(t => t.NameFrom() == x.NameFrom()|| namespacesInScope.Any(ns => $"{ns}.{t.NameFrom()}" == x.NameFrom()));
         

--- a/Cecilifier.Core/TypeDependency/DependencyOrder.cs
+++ b/Cecilifier.Core/TypeDependency/DependencyOrder.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.TypeDependency;
+
+public class DependencyOrder
+{
+    internal IReadOnlyList<BaseTypeDeclarationSyntax> Dependencies { get; }
+
+    public DependencyOrder(List<BaseTypeDeclarationSyntax> dependencies) => Dependencies = dependencies;
+
+    public override string ToString()
+    {
+        return string.Join(',', Dependencies.Select(d => d.Identifier.Text));
+    }
+}

--- a/Cecilifier.Core/TypeDependency/TypeDependencyCollector.cs
+++ b/Cecilifier.Core/TypeDependency/TypeDependencyCollector.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.TypeDependency;
+
+public class TypeDependencyCollector
+{
+    public TypeDependencyCollector(CSharpCompilation comp)
+    {
+        var visitor = new TypeDependencyCollectorVisitor(comp);
+        foreach (var st in comp.SyntaxTrees)
+            visitor.Visit(st.GetRoot());
+
+        Unordered = new DependencyOrder(new List<BaseTypeDeclarationSyntax>(visitor.Dependencies.Keys));
+        Ordered = SortByDependency(visitor.Dependencies, visitor.Usings);
+    }
+
+    private DependencyOrder SortByDependency(IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> dependencies, IReadOnlyList<string> usings)
+    {
+        var sortedDependency = new List<BaseTypeDeclarationSyntax>(dependencies.Keys);
+        sortedDependency.Sort(new DependencyComparer(dependencies, usings));
+        
+        return new DependencyOrder(sortedDependency);
+    }
+
+    public DependencyOrder Unordered { get; }
+    public DependencyOrder Ordered { get; }
+}

--- a/Cecilifier.Core/TypeDependency/TypeDependencyCollector.cs
+++ b/Cecilifier.Core/TypeDependency/TypeDependencyCollector.cs
@@ -16,7 +16,7 @@ public class TypeDependencyCollector
         Ordered = SortByDependency(visitor.Dependencies, visitor.Usings);
     }
 
-    private DependencyOrder SortByDependency(IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> dependencies, IReadOnlyList<string> usings)
+    private DependencyOrder SortByDependency(IDictionary<BaseTypeDeclarationSyntax, IDictionary<string, int>> dependencies, IReadOnlyList<string> usings)
     {
         var sortedDependency = new List<BaseTypeDeclarationSyntax>(dependencies.Keys);
         sortedDependency.Sort(new DependencyComparer(dependencies, usings));

--- a/Cecilifier.Core/TypeDependency/TypeDependencyCollectorVisitor.cs
+++ b/Cecilifier.Core/TypeDependency/TypeDependencyCollectorVisitor.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cecilifier.Core.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.TypeDependency;
+
+public class TypeDependencyCollectorVisitor : CSharpSyntaxWalker
+{
+    private readonly CSharpCompilation compilation;
+    private IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> dependencies = new Dictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>>();
+    private Stack<BaseTypeDeclarationSyntax> declaredTypes = new();
+    private List<string> usings = new();
+    
+    public TypeDependencyCollectorVisitor(CSharpCompilation compilation)
+    {
+        this.compilation = compilation;
+    }
+
+    public IDictionary<BaseTypeDeclarationSyntax, ISet<TypeSyntax>> Dependencies => dependencies;
+    public IReadOnlyList<string> Usings => usings;
+
+    public override void VisitUsingDirective(UsingDirectiveSyntax node)
+    {
+        usings.Add(node.Name.ToString());
+        base.VisitUsingDirective(node);
+    }
+
+    public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+    {
+        using (ProcessTypeDeclaration(node)) 
+            base.VisitClassDeclaration(node);
+    }
+
+    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+    {
+        using(ProcessTypeDeclaration(node))
+            base.VisitInterfaceDeclaration(node);
+    }
+
+    public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+    {
+        using(ProcessTypeDeclaration(node))
+            base.VisitEnumDeclaration(node);
+    }
+
+    public override void VisitStructDeclaration(StructDeclarationSyntax node)
+    {
+        using(ProcessTypeDeclaration(node))
+            base.VisitStructDeclaration(node);
+    }
+
+    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
+        base.VisitFieldDeclaration(node);
+    }
+
+    public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+        base.VisitPropertyDeclaration(node);
+    }
+
+    public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.ReturnType);
+        base.VisitMethodDeclaration(node);
+    }
+
+    public override void VisitEventDeclaration(EventDeclarationSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+        base.VisitEventDeclaration(node);
+    }
+
+    public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
+        base.VisitEventFieldDeclaration(node);
+    }
+
+    public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+        base.VisitObjectCreationExpression(node);
+    }
+    
+    public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
+        base.VisitLocalDeclarationStatement(node);
+    }
+
+    public override void VisitParameter(ParameterSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+        base.VisitParameter(node);
+    }
+
+    public override void VisitCastExpression(CastExpressionSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+    }
+
+    public override void VisitBinaryExpression(BinaryExpressionSyntax node)
+    {
+        if (!node.OperatorToken.IsKind(SyntaxKind.AsKeyword) && !node.OperatorToken.IsKind(SyntaxKind.IsKeyword))
+            return;
+        
+        if (node.Right is TypeSyntax type)
+            AddCurrentTypeDependencyIfNotTheSame(type);
+        
+        base.VisitBinaryExpression(node);
+    }
+
+    public override void VisitTypeConstraint(TypeConstraintSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+    }
+
+    public override void VisitTypeArgumentList(TypeArgumentListSyntax node)
+    {
+        foreach (var type in node.Arguments)
+        {
+            AddCurrentTypeDependencyIfNotTheSame(type);
+        }
+    }
+
+    public override void VisitArrayCreationExpression(ArrayCreationExpressionSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type.ElementType);
+        base.VisitArrayCreationExpression(node);
+    }
+
+    public override void VisitArgument(ArgumentSyntax node)
+    {
+        if(node.Expression is TypeSyntax type)
+            AddCurrentTypeDependencyIfNotTheSame(type);
+    }
+
+    public override void VisitTypeOfExpression(TypeOfExpressionSyntax node)
+    {
+        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+    }
+
+    private void AddCurrentTypeDependencyIfNotTheSame(TypeSyntax type)
+    {
+        if (declaredTypes.Count == 0 || type == null) // type can be null for lambda parameters, for instance.
+            return;
+        
+        var semanticModel = compilation.GetSemanticModel(type.SyntaxTree);
+        if (String.Compare(declaredTypes.Peek().Identifier.Text, type.NameFrom(), StringComparison.Ordinal) != 0 && semanticModel.GetSymbolInfo(type).Symbol is ITypeSymbol { IsDefinition: true })
+        {
+            dependencies[declaredTypes.Peek()].Add(type);
+        }
+    }
+    private DeclaredTypeTracker ProcessTypeDeclaration(BaseTypeDeclarationSyntax node)
+    {
+        var semanticModel = compilation.GetSemanticModel(node.SyntaxTree);
+
+        var currentTypeDependencies = new HashSet<TypeSyntax>();
+        dependencies.Add(node, currentTypeDependencies);
+
+        var basesInSameCompilation = node.BaseList?.Types.Where(t => semanticModel.GetTypeInfo(t.Type).Type?.IsDefinition == true) ?? Array.Empty<BaseTypeSyntax>();
+        foreach (var b in basesInSameCompilation)
+            currentTypeDependencies.Add(b.Type);
+
+        declaredTypes.Push(node);
+
+        return new DeclaredTypeTracker(declaredTypes);
+    }
+
+    internal struct DeclaredTypeTracker : IDisposable
+    {
+        private Stack<BaseTypeDeclarationSyntax> toPop;
+
+        public DeclaredTypeTracker(Stack<BaseTypeDeclarationSyntax> toPop) => this.toPop = toPop;
+
+        public void Dispose()
+        {
+            if (toPop != null)
+            {
+                toPop.Pop();
+                toPop = null;
+            }
+        }
+    }
+}

--- a/Cecilifier.Core/TypeDependency/TypeDependencyCollectorVisitor.cs
+++ b/Cecilifier.Core/TypeDependency/TypeDependencyCollectorVisitor.cs
@@ -53,98 +53,14 @@ public class TypeDependencyCollectorVisitor : CSharpSyntaxWalker
             base.VisitStructDeclaration(node);
     }
 
-    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    public override void VisitQualifiedName(QualifiedNameSyntax node)
     {
-        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
-        base.VisitFieldDeclaration(node);
+        AddCurrentTypeDependencyIfNotTheSame(node);
     }
 
-    public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-        base.VisitPropertyDeclaration(node);
-    }
-
-    public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.ReturnType);
-        base.VisitMethodDeclaration(node);
-    }
-
-    public override void VisitEventDeclaration(EventDeclarationSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-        base.VisitEventDeclaration(node);
-    }
-
-    public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
-        base.VisitEventFieldDeclaration(node);
-    }
-
-    public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-        base.VisitObjectCreationExpression(node);
-    }
-    
-    public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Declaration.Type);
-        base.VisitLocalDeclarationStatement(node);
-    }
-
-    public override void VisitParameter(ParameterSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-        base.VisitParameter(node);
-    }
-
-    public override void VisitCastExpression(CastExpressionSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-    }
-
-    public override void VisitBinaryExpression(BinaryExpressionSyntax node)
-    {
-        if (!node.OperatorToken.IsKind(SyntaxKind.AsKeyword) && !node.OperatorToken.IsKind(SyntaxKind.IsKeyword))
-            return;
-        
-        if (node.Right is TypeSyntax type)
-            AddCurrentTypeDependencyIfNotTheSame(type);
-        
-        base.VisitBinaryExpression(node);
-    }
-
-    public override void VisitTypeConstraint(TypeConstraintSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
-    }
-
-    public override void VisitTypeArgumentList(TypeArgumentListSyntax node)
-    {
-        foreach (var type in node.Arguments)
-        {
-            AddCurrentTypeDependencyIfNotTheSame(type);
-        }
-    }
-
-    public override void VisitArrayCreationExpression(ArrayCreationExpressionSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type.ElementType);
-        base.VisitArrayCreationExpression(node);
-    }
-
-    public override void VisitArgument(ArgumentSyntax node)
-    {
-        if(node.Expression is TypeSyntax type)
-            AddCurrentTypeDependencyIfNotTheSame(type);
-    }
-
-    public override void VisitTypeOfExpression(TypeOfExpressionSyntax node)
-    {
-        AddCurrentTypeDependencyIfNotTheSame(node.Type);
+        AddCurrentTypeDependencyIfNotTheSame(node);
     }
 
     private void AddCurrentTypeDependencyIfNotTheSame(TypeSyntax type)
@@ -174,7 +90,7 @@ public class TypeDependencyCollectorVisitor : CSharpSyntaxWalker
         return new DeclaredTypeTracker(declaredTypes);
     }
 
-    internal struct DeclaredTypeTracker : IDisposable
+    private struct DeclaredTypeTracker : IDisposable
     {
         private Stack<BaseTypeDeclarationSyntax> toPop;
 

--- a/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
+++ b/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
@@ -26,7 +26,8 @@ internal struct RoslynTypeSystem
         SystemString = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_String);
         SystemVoid = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Void);
         SystemObject = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Object);
-        SystemIDisposable = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(IDisposable).FullName); 
+        SystemIDisposable = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(IDisposable).FullName);
+        SystemRuntimeCompilerServices = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(IsReadOnlyAttribute).FullName); 
     }
     
     public ITypeSymbol SystemIndex { get; }
@@ -42,4 +43,6 @@ internal struct RoslynTypeSystem
     public ITypeSymbol SystemObject { get; }
     public ITypeSymbol CallerArgumentExpressionAttribute { get; }
     public ITypeSymbol SystemIDisposable { get; }
+
+    public ITypeSymbol SystemRuntimeCompilerServices { get; }
 }

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.60.0</AssemblyVersion>
+    <AssemblyVersion>1.70.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cecilifier.Runtime/TypeHelpers.cs
+++ b/Cecilifier.Runtime/TypeHelpers.cs
@@ -35,9 +35,10 @@ namespace Cecilifier.Runtime
                 .Where(c => c.Name == methodName
                             && c.IsGenericMethodDefinition
                             && c.GetParameters().Length == paramTypes.Count()
-                            && typeArgumentsCount == c.GetGenericArguments().Length);
+                            && typeArgumentsCount == c.GetGenericArguments().Length)
+                .ToArray();
 
-            if (methods == null)
+            if (methods.Length == 0)
             {
                 throw new MissingMethodException(declaringTypeName, methodName);
             }
@@ -100,24 +101,6 @@ namespace Cecilifier.Runtime
             if (resolvedMethod == null)
             {
                 throw new InvalidOperationException($"Failed to resolve method {declaringType}.{methodName}({string.Join(',', paramTypes)})");
-            }
-            
-            return resolvedMethod;
-        }
-
-        public static MethodInfo ResolveMethod(string assemblyName, string declaringTypeName, string methodName)
-        {
-            var containingAssembly = Assembly.Load(new AssemblyName(assemblyName));
-            var declaringType = containingAssembly.GetType(declaringTypeName);
-            if (declaringType == null)
-            {
-                throw new InvalidOperationException($"Failed to resolve type [{assemblyName}] {declaringTypeName}");
-            }
-
-            var resolvedMethod = declaringType.GetMethod(methodName);
-            if (resolvedMethod == null)
-            {
-                throw new InvalidOperationException($"Failed to resolve method [{assemblyName}] {declaringTypeName}.{methodName}(?)");
             }
             
             return resolvedMethod;

--- a/Cecilifier.Web/Cecilifier.Web.csproj
+++ b/Cecilifier.Web/Cecilifier.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <AssemblyVersion>1.60.0</AssemblyVersion>
+    <AssemblyVersion>1.70.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cecilifier.Web/Pages/Index.cshtml
+++ b/Cecilifier.Web/Pages/Index.cshtml
@@ -12,6 +12,8 @@
 }
 
 <div xmlns="http://www.w3.org/1999/html">
+    <span id="supportedCSharpVersion" hidden>@Core.Cecilifier.SupportedCSharpVersion</span>
+    
     <div id="settingsDiv" class="sidenav">
         <table style="width: 100%">
             <tr>
@@ -26,37 +28,42 @@
                 </td>
                 <td style='min-width:10px;'></td>
                 <td style='width:75%; text-align: left'>
-                    <div id="formattingSettingsSample-container" style="margin-bottom: 5px;"><div id="_formattingSettingsSample" style="width: 1000px; height: 1000px; border-left: 10px solid white; border-right: 10px solid white"></div></div>
+                    <div id="formattingSettingsSample-container" style="margin-bottom: 5px;">
+                        <div id="_formattingSettingsSample" style="width: 1000px; height: 1000px; border-left: 10px solid white; border-right: 10px solid white"></div></div>
                 </td>
             </tr>
         </table>
     </div>
 
-    <nav id="cecilifier-validation" class="navbar navbar-default navbar-fixed-top hidden" role="alert"> 
-        <div class="container"> 
-            <div class="navbar-header"> 
-                <span class="navbar-brand"> 
-                    <span class="glyphicon glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> 
+    <nav id="cecilifier-validation" class="navbar navbar-default navbar-fixed-top hidden" role="alert">
+        <div class="container">
+            <div class="navbar-header">
+                <span class="navbar-brand">
+                    <span class="glyphicon glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
                 </span>
             </div>
-            
-            <div class="collapse navbar-collapse"> 
-                <p class="navbar-text" id="cecilifier-validation-msg"></p> 
-                <div class="navbar-right"> 
+
+            <div class="collapse navbar-collapse">
+                <p class="navbar-text" id="cecilifier-validation-msg"></p>
+                <div class="navbar-right">
                     <button type="button" class="btn btn-default navbar-btn" data-cookie-string="" onclick="document.querySelector('#cecilifier-validation').classList.add('hidden')">
                         <span class="glyphicon glyphicon-remove"></span>
-                    </button> 
-                </div>  
-            </div> 
-        </div> 
-    </nav> 
+                    </button>
+                </div>
+            </div>
+        </div>
+    </nav>
 
     <div id="csharpcode-container" style="margin-bottom: 5px;">
-        <div id="csharpcode" style="width: 100%; height: 400px; border-left: 10px solid white; border-right: 10px solid white"></div>        
+        <div id="csharpcode" style="width: 100%; height: 400px; border-left: 10px solid white; border-right: 10px solid white"></div>
     </div>
-    
-    <div class="lds-ring" style="visibility: hidden" id="spinnerDiv"><div></div><div></div><div></div><div></div></div>
-    
+
+    <div class="lds-ring" style="visibility: hidden" id="spinnerDiv">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div></div>
+
     <div align="center" style="vertical-align: middle; margin-bottom: 5px;">
         <button type="submit" id="sendbutton" class="button">Cecilify your code!</button>
         <button type="submit" id="downloadProject" class="button">Generate Project <i class="fa fa-box"></i></button>
@@ -64,7 +71,7 @@
         <button class="button" onclick="changeCecilifierSettings();" id="changeSettings"><i class="fas fa-sliders-h"></i></button>
         <button class="button" id="showFixedBugsInStaging" onclick="showListOfFixedIssuesInStagingServer(true);"><i class="fa fa-bug fa-lg"></i></button>
         <button class="button" onclick="ShowAssemblyReferencesDialog('Assembly References', 'ssss');" id="assembly_references_button"><i class="fas fa-database"></i></button>
-        
+
         <span id="keyboard-shortcuts">
             <i class="fas fa-keyboard" style="font-size:28px; vertical-align: middle;"></i>
         </span>
@@ -76,50 +83,51 @@
     <div id="cecilifiedcode-container" style="margin-bottom: 0;">
         <div id="cecilifiedcode" style="width: 100%; height: 600px; border-left: 10px solid white; border-right: 10px solid white"></div>
     </div>
-    
+
     <div class="modal" aria-hidden="true">
-      <div class="modal-dialog" id="bug_reporter_dialog_id">
-        <div class="modal-header">
-          <h2 id="bug_reporter_header_id"><img src="images/oops.png" width="64" height="64"  alt="oops" style="margin-right: 10px"/>We've got an internal error.</h2>
-          <a href="#" class="btn-close closemodal" aria-hidden="true" onclick="CloseErrorDialog()">&times;</a>
+        <div class="modal-dialog" id="bug_reporter_dialog_id">
+            <div class="modal-header">
+                <h2 id="bug_reporter_header_id"><img src="images/oops.png" width="64" height="64" alt="oops" style="margin-right: 10px"/>We've got an internal error.</h2>
+                <a href="#" class="btn-close closemodal" aria-hidden="true" onclick="CloseErrorDialog()">&times;</a>
+            </div>
+            <div class="modal-body">
+                Title<br/>
+                <textarea id="error_title" style="width: 100%; resize: none" placeholder="enter a descriptive title" oninput="updateReportErrorButton(this)"></textarea><br/>
+
+                Description<br/>
+                <textarea id="error_description" style="width: 100%; resize: none"></textarea><br/>
+
+                <input type="checkbox" checked="true" id="include-snippet"/>Include original code.
+            </div>
+
+            <div class="modal-footer" id="bug_reporter_dialog_footer">
+                <a href="#" class="btn-disabled" onclick="fileIssueInGitHub();" id="report_internal_error_button">Report error</a> <a href="#" class="btn" onclick="CloseErrorDialog()">Close</a>
+            </div>
         </div>
-          <div class="modal-body">
-              Title<br/>
-              <textarea id="error_title" style="width: 100%; resize: none" placeholder="enter a descriptive title" oninput="updateReportErrorButton(this)"></textarea><br/>
-              
-              Description<br/>
-              <textarea id="error_description" style="width: 100%; resize: none"></textarea><br/>
-              
-              <input type="checkbox" checked="true" id="include-snippet" />Include original code.
-          </div>
-          
-          <div class="modal-footer" id="bug_reporter_dialog_footer">
-              <a href="#" class="btn-disabled" onclick="fileIssueInGitHub();" id="report_internal_error_button">Report error</a> <a href="#" class="btn" onclick="CloseErrorDialog()">Close</a>
-          </div>
-      </div>
     </div>
 
-    <!-- Assembly References Dialog --> 
+    <!-- Assembly References Dialog -->
     <div class="modal" aria-hidden="true">
         <div class="modal-dialog" id="assembly_references_dialog_id">
-            <div class="modal-header" id="assembly_references_header_id" style="background-color: #2b669a; padding-left: 10px;color: white"><h2 style="margin-top:0; margin-bottom: 0">Assembly References</h2><a href="#" class="btn-close closemodal" style="padding-top: 0;padding-bottom: 0" aria-hidden="true" onclick="CloseDialog()">&times;</a>
+            <div class="modal-header" id="assembly_references_header_id" style="background-color: #2b669a; padding-left: 10px;color: white">
+                <h2 style="margin-top:0; margin-bottom: 0">Assembly References</h2><a href="#" class="btn-close closemodal" style="padding-top: 0;padding-bottom: 0" aria-hidden="true" onclick="CloseDialog()">&times;</a>
             </div>
             <div class="modal-body" style="align-content: center">
                 <select id="assembly_references_list" size="12" style="width: 100%" ondrop="DropAssemblyReference(event)" ondragover="AllowDrop(event)"></select>
-                
-                <br />
+
+                <br/>
             </div>
-          
+
             <div align="left" style="vertical-align: middle; margin-bottom: 5px; margin-left: 20px">
                 <button class="button" id="remove_selected_assembly" onclick="removeSelectedAssemblyReference()"><i class="fas fa-eraser"></i></button>
             </div>
-            
+
             <div class="modal-footer" style="top:90%;left:94%">
                 <a href="#" class="btn-disabled" onclick="StoreReferenceAssembliesLocallyAndClose();" id="close_assembly_references_dialog">Close</a>
             </div>
         </div>
     </div>
-    
+
     <a href="javascript:void(0)" id="dlbtn" style="display: none"><button></button></a>
 </div>
 

--- a/Cecilifier.Web/Pages/Index.cshtml.cs
+++ b/Cecilifier.Web/Pages/Index.cshtml.cs
@@ -12,6 +12,8 @@ namespace Cecilifier.Web.Pages
     public class CecilifierApplication : PageModel
     {
         public static int Count;
+
+        public static int SupportedCSharpVersion => Core.Cecilifier.SupportedCSharpVersion;
         public string FromGist { get; private set; } = string.Empty;
         public string ErrorAccessingGist { get; private set; } = string.Empty;
 

--- a/Cecilifier.Web/Pages/Index.cshtml.cs
+++ b/Cecilifier.Web/Pages/Index.cshtml.cs
@@ -24,6 +24,11 @@ namespace Cecilifier.Web.Pages
         
         public async Task<IActionResult> OnGet()
         {
+            if (Request.Host.Host.Contains("staging.cecilifier.me"))
+            {
+                return Redirect("http://cecilifier.me:5000");
+            }
+            
             ErrorAccessingGist = null;
             if (Request.Query.TryGetValue("gistid", out var gistid))
             {

--- a/Cecilifier.Web/Pages/Shared/_Layout.cshtml
+++ b/Cecilifier.Web/Pages/Shared/_Layout.cshtml
@@ -119,7 +119,7 @@
                 <a class="fab fa-stack-overflow" href="https://stackoverflow.com/users/157321/vagaus"target="_so_cecilifier"></a>
                 <a class="fab fa-github" href="https://github.com/sponsors/adrianoc"target="_ghs_cecilifier"></a>
                 <a class="fab fa-discord" href="https://discord.gg/dhF5BCW"target="_pa_cecilifier"></a>
-                | &copy; 2022 - Adriano Carlos Verona (<span id="cecilified_counter">@CecilifierApplication.Count</span>)
+                <span>| &copy; 2022 - Adriano Carlos Verona (<span id="cecilified_counter">@CecilifierApplication.Count</span>)</span>
             </div>            
         </div>
     </footer>

--- a/Cecilifier.Web/wwwroot/js/cecilifier.js
+++ b/Cecilifier.Web/wwwroot/js/cecilifier.js
@@ -110,7 +110,13 @@ function initializeSite(errorAccessingGist, gist, version) {
     require(['vs/editor/editor.main'], function () {
         csharpCode = monaco.editor.create(document.getElementById('csharpcode'), {
             theme: "vs-dark",
-            value: ['using System;', 'class Foo', '{', '\tvoid Bar() => Console.WriteLine("Hello World!");', '}'].join('\n'),
+            value: [
+                `// Supported CSharp language version: ${document.getElementById('supportedCSharpVersion').innerText} https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-${document.getElementById('supportedCSharpVersion').innerText}`,
+                'using System;', 
+                'class Foo', 
+                '{', 
+                '\tvoid Bar() => Console.WriteLine("Hello World!");', 
+                '}'].join('\n'),
             language: 'csharp',
             minimap: { enabled: false },
             fontSize: 16,

--- a/Cecilifier.Web/wwwroot/js/cecilifier.js
+++ b/Cecilifier.Web/wwwroot/js/cecilifier.js
@@ -130,33 +130,33 @@ function initializeSite(errorAccessingGist, gist, version) {
          });
          
         // Configure keyboard shortcuts
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd  | monaco.KeyMod.Alt | monaco.KeyCode.KEY_D, function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyMod.Alt + monaco.KeyCode.KeyD, function() {
             simulateClick("downloadProject");
         });
 
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KEY_C, function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyMod.Alt + monaco.KeyCode.KeyC, function() {
             simulateClick("sendbutton");
         });
 
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KEY_S, function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyMod.Alt + monaco.KeyCode.KeyS, function() {
             changeCecilifierSettings();
         });
 
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.US_OPEN_SQUARE_BRACKET , function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyCode.BracketLeft , function() {
             const options = csharpCode.getRawOptions();
             const newFontSize = Math.ceil(options.fontSize - options.fontSize * 0.05);
 
             csharpCode.updateOptions({ fontSize: newFontSize });
         });
 
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.US_CLOSE_SQUARE_BRACKET , function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyCode.BracketRight , function() {
             const options = csharpCode.getRawOptions();
 
             const newFontSize = Math.ceil(options.fontSize * 1.05);
             csharpCode.updateOptions({ fontSize: newFontSize });
         });
 
-        csharpCode.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.US_DOT , function() {
+        csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyCode.Period, function() {
             ShowErrorDialog("Report a new issue", "Please be kind, check the existing ones before filing a new issue..", "Report an error.");
         });
         

--- a/Notes/monaco_hover_provider.md
+++ b/Notes/monaco_hover_provider.md
@@ -1,0 +1,111 @@
+```javascript
+
+// POC for displaying link for IL opcodes
+// Another possibility is to add info/help for Cecil APIs
+// or explanations about why/how these APIs are used.
+monaco.languages.register({ id: 'mySpecialLanguage' });
+
+monaco.languages.registerHoverProvider('mySpecialLanguage', {
+	provideHover: function (model, position) {
+        let atPosition = model.getWordAtPosition(position);
+        let line = model.getLineContent(position.lineNumber);
+
+        //console.log(`${atPosition.endColumn} : ${line.charAt(atPosition.endColumn-1)}`);
+        if (atPosition.word === "OpCodes" && line.charAt(atPosition.endColumn - 1) === '.')
+        {
+            let nextWord = model.getWordAtPosition(new monaco.Position(position.lineNumber, atPosition.endColumn + 1))
+                return {
+                    range: new monaco.Range(
+                        1,
+                        1,
+                        model.getLineCount(),
+                        model.getLineMaxColumn(model.getLineCount())
+                    ),
+                    contents: [
+                        { value: '**SOURCE**' },
+                        { 
+                            supportHtml: true,                            
+                            value: `OpCode: <a href="https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.${nextWord.word}">${nextWord.word}</a>`
+                        }
+                    ]
+                };
+        }
+        
+        let index = line.indexOf("OpCodes.");
+        while (index != -1)
+        {
+            let found = model.getWordAtPosition(new monaco.Position(position.lineNumber, index + 1));
+            //console.log(`Index: ${index}, FoundEnd: ${found.endColumn} AtPosition: ${atPosition.startColumn}`);
+            
+            if (found.endColumn + 1 === atPosition.startColumn)
+            {
+                return {
+                    range: new monaco.Range(
+                        1,
+                        1,
+                        model.getLineCount(),
+                        model.getLineMaxColumn(model.getLineCount())
+                    ),
+                    contents: [
+                        { value: '**SOURCE**' },
+                        { value: `https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.${atPosition.word}` }
+                    ]
+                };
+            }
+
+            index = line.indexOf("OpCodes.", found.endColumn + 1);
+            console.log(`${index}, ${position.lineNumber } ${found.endColumn + 1}`);
+        }
+
+			return {
+				range: new monaco.Range(
+					1,
+					1,
+					model.getLineCount(),
+					model.getLineMaxColumn(model.getLineCount())
+				),
+				contents: [
+					{ value: '**SOURCE**' },
+					{ value: `line: ${model.getLineContent(position.lineNumber)}\nword: ${atPosition.word}` }
+				]
+			};
+	}
+});
+
+monaco.editor.create(document.getElementById('container'), {
+	value: '\n\nHover over this text',
+	language: 'mySpecialLanguage'
+});
+
+function xhr(url) {
+	var req = null;
+	return new Promise(
+		function (c, e) {
+			req = new XMLHttpRequest();
+			req.onreadystatechange = function () {
+				if (req._canceled) {
+					return;
+				}
+
+				if (req.readyState === 4) {
+					if ((req.status >= 200 && req.status < 300) || req.status === 1223) {
+						c(req);
+					} else {
+						e(req);
+					}
+					req.onreadystatechange = function () {};
+				}
+			};
+
+			req.open('GET', url, true);
+			req.responseType = '';
+
+			req.send(null);
+		},
+		function () {
+			req._canceled = true;
+			req.abort();
+		}
+	);
+}
+```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ These resembles tradicional Unit tests, at least from performance characteristic
 
 - Pros
 	- Performance: since there's no compilation involved these tests are much faster than the [Integration](#integration-tests) ones.
-	- More easily debuggable
+	- Easier to debug/investigate issues.
 - Cons
 	- Sensitive to changes in the way code is generated leading to false positives when naming rules, formating, etc. changes.
 	- Sensitive to false positives due to, in general, not verifying all the generated code (which would be impratical)	- 
@@ -113,6 +113,18 @@ Integration Tests
 ---
 
 These tests work basically taking a [snippet of code](https://github.com/adrianoc/cecilifier/blob/dev/Cecilifier.Core.Tests/TestResources/Integration/CodeBlock/Conditional/IfStatement.cs.txt), _Cecilifying_ it (generating the Mono.Cecil API calls to produce an assembly equivalent to the compiled snippet), compiling it,  and finally either comparing the two assemblies or comparing the generated IL for some method with the expected output [as in this example](https://github.com/adrianoc/cecilifier/blob/dev/Cecilifier.Core.Tests/TestResources/Integration/CodeBlock/Conditional/IfStatement.cs.il.txt). 
+
+```mermaid
+	graph TD;
+		Snippet-->Compile;
+		Snippet-->Cecilify([Cecilify]);
+		Compile-->Assembly;
+		Assembly-->CompAssemblies;
+		Cecilify-->CompCecilified[Compile Cecilified];
+		CompCecilified-->RunCecilified[Run Cecilified];
+		RunCecilified-->|outputs|CecilifiedAssembly[Cecilified Assembly]
+		CecilifiedAssembly-->CompAssemblies[Compare Assemblies]
+```
 
 Ideally all tests in this category should use the assembly comparison approach (as opposed to forcing 
 developers to store the expected IL) but in some cases the comparison code would became too complex and in such cases I think it is ok to store the expected IL (anyway, I try to minimize the number of such tests).


### PR DESCRIPTION
Changes/Fixes

e7c0f54 updated CHANGELOG.md to reflect changes
4ef078b renames nonsensical method
0ebcc3d fixes compound assignment handling (#197)
d492df1 cleans up tests for modulus operator
b465b78 adds support for 'raw literal strings'
d2684ba fixes 'AssemblyQualifiedName()' return for 'nint'
6e41157 ignore attribute added by updated Roslyn
a4efc84 allow tests to run on major version greater than 6.0
b642e9e updates Microsoft.CodeAnalysis.CSharp, NUnit3TestAdapter and coverlet.collector packages
d9bc5d9 more code cleanup to avoid code duplicaton
46bb167 refactored code handling type/member modifiers -> cil attributes (part of #158)
7970188 add support for readonly struct declarations (part of #158)
fd6b2ce show supported language version as commnent in the snippet template
05505da improves handling of forwarded type references used as type arguments and as field type (#188 & #196)
3e43f6e code cleanup
e4c2984 renames method to a more decriptive name
8b37d04 sample javascript code to show a popup (hover) with links to the selected IL opcode
baf28dd implements automatic websocket reconnection
16194bb updated integration tests workflow in README.md
dba4a7c sorts dependencies taking into account number of times the types are referenced
b21ca17 changes type dependency collection to rely on more generic visitor
28ac724 updates CHANGELOG.md
9298a0d improves TypeHelper tests + adds line information for throw expressions
9f27f82 sort type declarations by dependency before processing
d6158f8 fixes shortcut handling
fb5c49e redirects access to staging.cecilifier.me to the staging server
de37461 bumps version to 1.70
