### PR TITLE
October 2024 Updates 2 (Version 2.15)

### DIFF
--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
-    <AssemblyVersion>2.14.0</AssemblyVersion>
+    <AssemblyVersion>2.15.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/Cecilifier.CommonPackages.props
+++ b/Cecilifier.CommonPackages.props
@@ -2,6 +2,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0-1.final" /> 
-    <PackageReference Include="Mono.Cecil"><Version>0.11.5</Version></PackageReference>
+    <PackageReference Include="Mono.Cecil"><Version>0.11.6</Version></PackageReference>
   </ItemGroup>
 </Project>

--- a/Cecilifier.Core.Tests/Tests/OutputBased/CollectionExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/CollectionExpressionTests.cs
@@ -53,7 +53,29 @@ public class CollectionExpressionTests : OutputBasedTestBase
             foreach(var c in list.ToArray()) System.Console.Write(c);
             """, 
             "CECIL");
-    }    
+    }
+
+    [Test]
+    public void X()
+    {
+        AssertOutput(
+            """
+            using System.Collections.Generic;
+            List<Bar> list = [new Bar(1), new Bar(2)];
+            
+            for(List<Bar>.Enumerator enumerator = list.GetEnumerator(); enumerator.MoveNext();)
+                System.Console.Write(enumerator.Current);
+            
+            class Bar 
+            {
+                public Bar(int i) => Value = i;
+                public override string ToString() => Value.ToString();
+                public int Value;
+            }
+            """, 
+            "12");
+        
+    }
     
     [Test]
     public void ImplicitNumericConversions_Are_Applied([Values("List<long>", "long[]", "Span<long>")] string targetType, [Values("[2, 1]", "[5, 4, 3, 2, 1]")] string items)

--- a/Cecilifier.Core.Tests/Tests/Unit/ArrayTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ArrayTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using Mono.Cecil.Cil;
 using NUnit.Framework;
 

--- a/Cecilifier.Core.Tests/Tests/Unit/AttributesTest.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/AttributesTest.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/CastTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/CastTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/CecilifiedOutputTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/CecilifiedOutputTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Cecilifier.Core.Misc;
 using Cecilifier.Core.Tests.Framework;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/CollectionExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/CollectionExpressionTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ConstTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ConstTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using Mono.Cecil.Cil;
 using NUnit.Framework;
 

--- a/Cecilifier.Core.Tests/Tests/Unit/CustomValueTypesInstantiationTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/CustomValueTypesInstantiationTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/DefaultExpressions.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/DefaultExpressions.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/DelegateTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/EventsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/EventsTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ExternalMembersTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ExternalMembersTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/FieldsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/FieldsTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ForEachStatementTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ForEachStatementTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ForStatementTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ForStatementTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/Framework/CecilifierContextBasedTestBase.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Framework/CecilifierContextBasedTestBase.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cecilifier.Core.Misc;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit.Framework;
+
+internal abstract class CecilifierContextBasedTestBase
+{
+    protected abstract string Snippet { get;  }
+    protected virtual IEnumerable<MetadataReference> ExtraAssemblyReferences() => [];
+    
+    private CSharpCompilation _comp;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(Snippet);
+        
+        _comp = CSharpCompilation.Create(
+            "TypeResolverTests",
+            [syntaxTree],
+            [
+                ..ExtraAssemblyReferences(),
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(List<>).Assembly.Location),
+            ],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var diagnostics = _comp.GetDiagnostics();
+        if (diagnostics.Any())
+        {
+            throw new InvalidOperationException(diagnostics.Aggregate("", (acc, diag) => $"{acc}\n{diag}"));
+        }
+    }
+
+    protected MethodDeclarationSyntax GetMethodSyntax(CecilifierContext context, string methodName)
+    {
+        return context.SemanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.Text == methodName);
+    }
+    
+    protected CecilifierContext NewContext() => new(_comp.GetSemanticModel(_comp.SyntaxTrees[0]), new CecilifierOptions(), 1);
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/Framework/CecilifierUnitTestBase.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Framework/CecilifierUnitTestBase.cs
@@ -4,7 +4,7 @@ using Cecilifier.Core.Misc;
 using Cecilifier.Core.Naming;
 using NUnit.Framework;
 
-namespace Cecilifier.Core.Tests.Tests.Unit
+namespace Cecilifier.Core.Tests.Tests.Unit.Framework
 {
     public class CecilifierUnitTestBase
     {

--- a/Cecilifier.Core.Tests/Tests/Unit/GenericTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/GenericTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/InlineArrayTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/InlineArrayTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/InterfaceTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/InterfaceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.RegularExpressions;
 using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/InterpolatedStringsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/InterpolatedStringsTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/InvocationOnValueTypeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/InvocationOnValueTypeTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/LambdaExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/LambdaExpressionTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/LocalFunctionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/LocalFunctionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/MethodExtensionsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MethodExtensionsTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+#nullable enable
+
+[TestFixture]
+internal class MethodExtensionsTests : CecilifierContextBasedTestBase
+{
+    protected override string Snippet => """
+                                         using System.Threading.Tasks;
+                                         public class Foo
+                                         {
+                                            Task TopLevelType(TaskCompletionSource<int> tcs) => tcs.Task.ContinueWith(null);
+                                         }
+                                         """;
+    protected override IEnumerable<MetadataReference> ExtraAssemblyReferences() => [MetadataReference.CreateFromFile(typeof(TestScenario).Assembly.Location)];
+
+    [Test]
+    public void ResolvingTypesFromExternalAssembly_UsesReflectionName()
+    {
+        var context = NewContext();
+       
+        var methodSyntax = GetMethodSyntax(context, "TopLevelType");
+        var continueWithInvocation = methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+
+        var methodSymbol = context.SemanticModel.GetSymbolInfo(continueWithInvocation.Expression).Symbol as IMethodSymbol;
+
+        var resolvedMethod = methodSymbol.MethodResolverExpression(context);
+        Assert.That(resolvedMethod, Does.Match(""".+ImportReference\(.+ResolveMethod\(typeof\(.+Task\<System.Int32\>\), "ContinueWith",.+, "System.Action`1\[\[System.Threading.Tasks.Task`1\[\[System.Int32\]\]\]\]"\)\)"""));
+    }
+    
+    [Test]
+    public void ResolvingInnerTypesFromExternalAssembly_UsesReflectionName()
+    {
+        var context = NewContext();
+
+        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.TestScenario");
+        var testMethod = testType.GetMembers("UseNestedType").Single().EnsureNotNull<ISymbol, IMethodSymbol>();
+
+        var resolvedMethod = testMethod.MethodResolverExpression(context);
+        Assert.That(resolvedMethod, Does.Match(""".+ImportReference\(.+ResolveMethod\(typeof\(.+TestScenario\), "UseNestedType",.+, "Cecilifier.Core.Tests.Tests.Unit.SomeClass`1\[\[System.Int32\]\]\+Cecilifier.Core.Tests.Tests.Unit.Inner"""));
+    }
+}
+
+public class TestScenario
+{
+    public void UseNestedType(SomeClass<int>.Inner inner) {}
+}
+
+public class SomeClass<T>
+{
+    public class Inner { }
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/MethodTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MethodTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Assingment.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Assingment.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Statements.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Statements.cs
@@ -34,7 +34,7 @@ public partial class MiscellaneousStatements : CecilifierUnitTestBase
                  \s+var (lbl_fel_\d+) = il_M_7.Create\(OpCodes.Nop\);
                  \s+var nop_10 = il_M_7.Create\(OpCodes.Nop\);
                  \s+il_M_7.Append\(nop_10\);
-                 \s+//for condition
+                 \s+//for condition: j < 10
                  \s+il_M_7.Emit\(OpCodes.Ldloc, l_j_8\);
                  \s+il_M_7.Emit\(OpCodes.Ldc_I4, 10\);
                  \s+il_M_7.Emit\(OpCodes.Clt\);

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Statements.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.Statements.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Miscellaneous.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/MiscellaneousMemberTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MiscellaneousMemberTests.cs
@@ -13,4 +13,14 @@ public class MiscellaneousMemberTests : CecilifierUnitTestBase
         var result = RunCecilifier(source);
         Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(expectedRegEx));
     }
+
+    [TestCase("[System.Runtime.CompilerServices.SkipLocalsInit] void Method() { int i; }", TestName = "Local function in global statement")]
+    [TestCase("void Foo() { [System.Runtime.CompilerServices.SkipLocalsInit] void Method() { int i; } }", TestName = "Local function")]
+    [TestCase("class Foo { [System.Runtime.CompilerServices.SkipLocalsInit] void Method() { int i; } }", TestName = "Member method")]
+    public void SkipLocalsInitAttribute_IsRespected(string snippet)
+    {
+        var result = RunCecilifier(snippet);
+        
+        Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(@"m_method_\d+\.Body.InitLocals = false;"));
+    }
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/MiscellaneousMemberTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MiscellaneousMemberTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/NameOfTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/NameOfTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/NullableTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/NullableTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ObjectInitializerTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ObjectInitializerTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/OperatorOverloadingTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/OperatorOverloadingTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using Microsoft.CodeAnalysis;
 using Mono.Cecil.Cil;
 using static System.Environment;

--- a/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/OperatorsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using Mono.Cecil.Cil;
 using NUnit.Framework;
 

--- a/Cecilifier.Core.Tests/Tests/Unit/ParameterTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ParameterTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/PatternExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/PatternExpressionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/PointerTypeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/PointerTypeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core.Tests/Tests/Unit/PropertyTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/PropertyTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/RefAssignmentTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/RefAssignmentTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/RefReturnTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/RefReturnTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/StackallocTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StackallocTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/StringTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StringTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/SystemIndexTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/SystemIndexTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using Microsoft.CodeAnalysis;
 using Mono.Cecil.Cil;
 using NUnit.Framework;

--- a/Cecilifier.Core.Tests/Tests/Unit/SystemRangeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/SystemRangeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/SystemSpanTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/SystemSpanTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/ThrowStatementAndExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ThrowStatementAndExpressionTests.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeResolutionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeResolutionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeTests.Generics.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeTests.Generics.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeTests.Records.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeTests.Records.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.RegularExpressions;
 using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;

--- a/Cecilifier.Core.Tests/Tests/Unit/UnsupportedFeaturesTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/UnsupportedFeaturesTestCase.cs
@@ -1,3 +1,4 @@
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit

--- a/Cecilifier.Core/AST/IVisitorContext.cs
+++ b/Cecilifier.Core/AST/IVisitorContext.cs
@@ -11,7 +11,7 @@ using Mono.Cecil.Cil;
 
 namespace Cecilifier.Core.AST
 {
-    internal interface IVisitorContext
+    public interface IVisitorContext
     {
         ServiceCollection Services { get; }
         

--- a/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Cecilifier.Core.Extensions;
 using Cecilifier.Core.Mappings;
 using Cecilifier.Core.Misc;
@@ -161,7 +162,7 @@ namespace Cecilifier.Core.AST
                     if (!methodSymbol.IsAbstract)
                     {
                         ilVar = Context.Naming.ILProcessor(simpleName);
-                        AddCecilExpression($"{methodVar}.Body.InitLocals = true;");
+                        AddCecilExpression($"{methodVar}.Body.InitLocals = {(!methodSymbol.TryGetAttribute<SkipLocalsInitAttribute>(out var _)).ToString().ToLower()};");
                         AddCecilExpression($"var {ilVar} = {methodVar}.Body.GetILProcessor();");
                     }
 

--- a/Cecilifier.Core/AST/StatementVisitor.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.cs
@@ -52,7 +52,7 @@ namespace Cecilifier.Core.AST
 
             var forConditionLabel = AddCilInstructionWithLocalVariable(_ilVar, OpCodes.Nop);
 
-            Context.WriteComment("for condition");
+            Context.WriteComment($"for condition: {node.Condition.HumanReadableSummary()}");
             // Condition
             ExpressionVisitor.Visit(Context, _ilVar, node.Condition);
             Context.EmitCilInstruction(_ilVar, OpCodes.Brfalse, forEndLabel);

--- a/Cecilifier.Core/AST/UsageResult.cs
+++ b/Cecilifier.Core/AST/UsageResult.cs
@@ -6,6 +6,7 @@ struct UsageResult
 {
     public UsageKind Kind { get; }
     public ISymbol Target { get; }
+    public static UsageResult None = new(UsageKind.None, null); 
 
     public static implicit operator UsageKind(UsageResult result) => result.Kind;
 

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -237,5 +237,10 @@ namespace Cecilifier.Core.Extensions
             attributeData = symbol.GetAttributes().SingleOrDefault(attr => attr.AttributeClass?.Name == typeOfT.Name);
             return attributeData != null;
         }
+        public static bool HasTypeArgumentOfTypeFromCecilifiedCodeTransitive(this INamedTypeSymbol type, IVisitorContext context)
+        {
+            return type.TypeArguments.Any(t => t.IsDefinedInCurrentAssembly(context)) 
+                   || (type.ContainingType != null && (SymbolEqualityComparer.Default.Equals(type.ContainingType, type) ? false : HasTypeArgumentOfTypeFromCecilifiedCodeTransitive(type.ContainingType, context)));
+        }
     }
 }

--- a/Cecilifier.Core/Extensions/MethodExtensions.cs
+++ b/Cecilifier.Core/Extensions/MethodExtensions.cs
@@ -164,7 +164,8 @@ namespace Cecilifier.Core.Extensions
 
             if (method.Parameters.Any(p => p.Type.IsTypeParameterOrIsGenericTypeReferencingTypeParameter()) 
                 || method.ReturnType.IsTypeParameterOrIsGenericTypeReferencingTypeParameter()
-                || method.ContainingType.TypeArguments.Any(t => t.IsDefinedInCurrentAssembly(ctx)))
+                || method.ContainingType.TypeArguments.Any(t => t.IsDefinedInCurrentAssembly(ctx))
+                || method.ContainingType.HasTypeArgumentOfTypeFromCecilifiedCodeTransitive(ctx))
             {
                 return ResolveMethodFromGenericType(method, ctx);
             }
@@ -213,7 +214,7 @@ namespace Cecilifier.Core.Extensions
         {
             // resolve declaring type of the method.
             var targetTypeVarName = ctx.Naming.SyntheticVariable($"{method.ContainingType.Name}", ElementKind.LocalVariable);
-            var resolvedTargetTypeExp = ctx.TypeResolver.Resolve(method.ContainingType.OriginalDefinition).MakeGenericInstanceType(method.ContainingType.TypeArguments.Select(t => ctx.TypeResolver.Resolve(t)));
+            var resolvedTargetTypeExp = ctx.TypeResolver.Resolve(method.ContainingType.OriginalDefinition).MakeGenericInstanceType(method.ContainingType.GetAllTypeArguments().Select(t => ctx.TypeResolver.Resolve(t)));
             ctx.WriteCecilExpression($"var {targetTypeVarName} = {resolvedTargetTypeExp};");
             ctx.WriteNewLine();
 

--- a/Cecilifier.Core/Extensions/MethodExtensions.cs
+++ b/Cecilifier.Core/Extensions/MethodExtensions.cs
@@ -17,7 +17,7 @@ using static Cecilifier.Core.Misc.Utils;
 
 namespace Cecilifier.Core.Extensions
 {
-    internal static class MethodExtensions
+    public static class MethodExtensions
     {
         public static TypeParameterSyntax[] GetTypeParameterSyntax(this IMethodSymbol method)
         {
@@ -170,7 +170,7 @@ namespace Cecilifier.Core.Extensions
                 return ResolveMethodFromGenericType(method, ctx);
             }
 
-            return ImportFromMainModule($"TypeHelpers.ResolveMethod(typeof({declaringTypeName}), \"{method.Name}\",{method.ReflectionBindingsFlags()}{method.Parameters.Aggregate("", (acc, curr) => acc + ", \"" + curr.Type.FullyQualifiedName() + "\"")})");
+            return ImportFromMainModule($"TypeHelpers.ResolveMethod(typeof({declaringTypeName}), \"{method.Name}\",{method.ReflectionBindingsFlags()}{method.Parameters.Aggregate("", (acc, curr) => acc + ", \"" + curr.Type.GetReflectionName() + "\"")})");
         }
 
         private static (HashSet<ITypeParameterSymbol>, bool) CollectReferencedMethodTypeParameters(IMethodSymbol method)

--- a/Cecilifier.Core/Extensions/TypeExtensions.cs
+++ b/Cecilifier.Core/Extensions/TypeExtensions.cs
@@ -179,6 +179,27 @@ namespace Cecilifier.Core.Extensions
         {
             return typeSymbol.Interfaces.Select(itf => context.TypeResolver.Resolve(itf));
         }
+        
+        
+        /// <summary>
+        /// Returns a list of type arguments used in the generic type instantiation of <paramref name="type"/> 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// For nested types this list includes all type's type arguments and *all* type arguments from *all*
+        /// parent types.
+        ///
+        /// For instance, given the type <![CDATA[Foo<int>.Bar<string,bool>.FooBar]]> this method will return
+        /// [int, string, bool]
+        /// </remarks>
+        public static IEnumerable<ITypeSymbol> GetAllTypeArguments(this INamedTypeSymbol type)
+        {
+            if (type.ContainingType == null)
+                return type.TypeArguments;
+                
+            return type.ContainingType.GetAllTypeArguments().Concat(type.TypeArguments);
+        }
     }
 
     public sealed class VariableDefinitionComparer : IEqualityComparer<VariableDefinition>

--- a/Cecilifier.Core/Misc/CecilifierContext.cs
+++ b/Cecilifier.Core/Misc/CecilifierContext.cs
@@ -14,7 +14,7 @@ using Mono.Cecil.Cil;
 
 namespace Cecilifier.Core.Misc
 {
-    internal class CecilifierContext : IVisitorContext
+    public class CecilifierContext : IVisitorContext
     {
         private readonly IDictionary<string, string> flags = new Dictionary<string, string>();
         private readonly LinkedList<string> output = new();

--- a/Cecilifier.Core/TypeSystem/Bcl.cs
+++ b/Cecilifier.Core/TypeSystem/Bcl.cs
@@ -2,7 +2,7 @@ using Cecilifier.Core.Misc;
 
 namespace Cecilifier.Core.TypeSystem
 {
-    internal sealed class Bcl
+    public sealed class Bcl
     {
         public Bcl(ITypeResolver typeResolver, CecilifierContext cecilifierContext)
         {

--- a/Cecilifier.Core/TypeSystem/ITypeResolver.cs
+++ b/Cecilifier.Core/TypeSystem/ITypeResolver.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Cecilifier.Core.TypeSystem
 {
-    internal interface ITypeResolver
+    public interface ITypeResolver
     {
         string Resolve(ITypeSymbol type, string cecilTypeParameterProviderVar = null);
         string Resolve(string typeName);

--- a/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
+++ b/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
@@ -11,7 +11,7 @@ namespace Cecilifier.Core.TypeSystem;
 /// RoslynTypeSystem contains Roslyn symbols for common types. These are useful when one needs to
 /// compare or emit code referencing those types. 
 /// </summary>
-internal struct RoslynTypeSystem
+public struct RoslynTypeSystem
 {
     public RoslynTypeSystem(IVisitorContext ctx)
     {

--- a/Cecilifier.Core/TypeSystem/SystemTypeSystem.cs
+++ b/Cecilifier.Core/TypeSystem/SystemTypeSystem.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Cecilifier.Core.TypeSystem
 {
-    internal class SystemTypeSystem
+    public class SystemTypeSystem
     {
         public SystemTypeSystem(ITypeResolver typeResolver, IVisitorContext context)
         {

--- a/Cecilifier.Runtime/TypeHelpers.cs
+++ b/Cecilifier.Runtime/TypeHelpers.cs
@@ -10,6 +10,15 @@ namespace Cecilifier.Runtime
 {
     public class TypeHelpers
     {
+        public static TypeReference NewRawNestedTypeReference(string typeName, ModuleDefinition module, TypeReference declaringType, bool isValueType, int typeParameterCount)
+        {
+            var typeReference = new TypeReference(String.Empty, typeName, module, declaringType.Scope) { DeclaringType = declaringType, IsValueType = isValueType ? true : false };
+            for(int i =0; i < typeParameterCount; i++)
+                typeReference.GenericParameters.Add(new GenericParameter(typeReference));
+            
+            return typeReference;
+        }
+
         public static MethodReference DefaultCtorFor(TypeReference type)
         {
             var resolved = type.Resolve();


### PR DESCRIPTION
d4aa7bc2 updates Mono.Cecil package from 0.11.5 -> 0.11.6
c1709386 bumps version to 2.15.0
2117d49d cecilified code respects 'SkipLocalsInitAttribute' (#220)
cf58feb4 fix incorrect name being used when interacting with reflection APIs in some scenarios (#304)
bf49b02d extracted CecilifierContextBasedTestBase from TypeResolverTests to simplify writing unit tests
2220a5e6 fixes calls to 'Object.GetType()' on value types generating incorrect code (#298)
dbd20e46 improves generated code for 'foreach' statements
5d1b8551 fixes resolving nested, non generic types of generic parent types with type arguments from the cecilified code (#306)
11e9183f use SemanticModel.GetForEachStatementInfo() instead of custom code to resolve IEnumerable/IEnumerator members  (#305)
