### PR TITLE
May 2025 Update - Version 2.21

### DIFF
--- a/.github/workflows/cecilifier-ci.yml
+++ b/.github/workflows/cecilifier-ci.yml
@@ -8,8 +8,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
-      - run: dotnet tool install --global dotnet-ilverify --version 8.0.0
+          dotnet-version: '9.0.x'
+      - run: dotnet tool install --global dotnet-ilverify --version 9.0.0
       - run: dotnet restore
       - run: dotnet test --filter 'TestCategory !~ Issues' --collect:"XPlat Code Coverage"
       - run: dotnet format style --verify-no-changes

--- a/Cecilifier.Benchmarks/Cecilifier.Benchmarks.csproj
+++ b/Cecilifier.Benchmarks/Cecilifier.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Cecilifier.Benchmarks/Program.cs
+++ b/Cecilifier.Benchmarks/Program.cs
@@ -13,7 +13,7 @@ public class Program
 public class CecilifierExtensionsBenchmarks
 {
     [ParamsSource(nameof(PascalCaseValues))]
-    public string PascalCaseValue { get; set; }
+    private string PascalCaseValue { get; set; } = string.Empty;
 
     [Benchmark(Baseline = true)]
     public string PascalCaseNaive()

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <AssemblyVersion>2.21.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
-    <AssemblyVersion>2.20.0</AssemblyVersion>
+    <AssemblyVersion>2.21.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Only copy english resource assemblies -->

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -4,6 +4,7 @@
     <LangVersion>13</LangVersion>
     <AssemblyVersion>2.21.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Only copy english resource assemblies -->
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <AssemblyVersion>2.21.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Cecilifier.CommonPackages.props
+++ b/Cecilifier.CommonPackages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0-1.final" /> 
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" /> 
     <PackageReference Include="Mono.Cecil"><Version>0.11.6</Version></PackageReference>
   </ItemGroup>
 </Project>

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -2,16 +2,18 @@
   <Import Project="../Cecilifier.Common.props" />
   <Import Project="../Cecilifier.CommonPackages.props" />
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ILVerification" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.ILVerification" Version="10.0.0-preview.2.25163.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0-beta.5" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cecilifier.Core\Cecilifier.Core.csproj" />

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -1,19 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Cecilifier.Common.props" />
   <Import Project="../Cecilifier.CommonPackages.props" />
+  
+  <PropertyGroup>
+    <!--
+    NuGet resolution complains about `Microsoft.CodeAnalysis.CSharp 4.13.0` requiring `System.Reflection.Metadata (>= 9.0.0-rtm.24511.16)` 
+    but according to https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp#dependencies-body-tab when targeting
+    .NET 9.0 it depends on `System.Reflection.Metadata (>= 8.0.0)` 
+    
+    Cecilifier.Core.Tests.csproj: Warning NU1603 : Microsoft.CodeAnalysis.CSharp 4.13.0 depends on System.Reflection.Metadata (>= 9.0.0-rtm.24511.16) but System.Reflection.Metadata 9.0.0-rtm.24511.16 was not found. System.Reflection.Metadata 9.0.0 was resolved instead. 
+    -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ILVerification" Version="10.0.0-preview.2.25163.2" />
+    <PackageReference Include="Microsoft.ILVerification" Version="9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0-beta.5" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cecilifier.Core\Cecilifier.Core.csproj" />

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 
 class GenericTypesAsMembers
 {
-    public IList<int> field;
-    public IList<int> Property { get { return field; } set { field = value; } }
+    public IList<int> asField;
+    public IList<int> Property { get { return asField; } set { asField = value; } }
     
     public IList<string> Method(IList<string> l)
     {

--- a/Cecilifier.Core.Tests/TestResources/Integration/Members/Methods/RefProperties.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Members/Methods/RefProperties.cs.txt
@@ -1,9 +1,9 @@
 ﻿class RefProperties
 {
-    private int field;
+    private int prop;
 	ref int Property
 	{
-		get => ref field;
+		get => ref prop;
 	}
 	
 	public ref int UseRefProperty() => ref Property;

--- a/Cecilifier.Core.Tests/Tests/OutputBased/NullCoalescingOperatorTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/NullCoalescingOperatorTests.cs
@@ -60,6 +60,6 @@ public class NullCoalescingOperatorTests : OutputBasedTestBase
     {
         AssertOutput($"System.Console.Write({Quote(a)} ?? {Quote(b)} ?? {Quote(c)});", expectedOutput);
         
-        string? Quote(string s) => s == null ? "null" : $"\"{s}\"";
+        string Quote(string s) => s == null ? "null" : $"\"{s}\"";
     }
 }

--- a/Cecilifier.Core.Tests/Tests/OutputBased/RecordTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/RecordTests.cs
@@ -100,7 +100,7 @@ public class RecordTests
     }
 
     [TestFixture]
-    public class Equals : OutputBasedTestBase
+    public class EqualsOverloadTest : OutputBasedTestBase
     {
         [Test]
         public void RecordTypeOverload_WhenInheritingFromObject_Works()

--- a/Cecilifier.Core.Tests/Tests/Unit/MemberDependencies/MemberDependencyTestBase.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MemberDependencies/MemberDependencyTestBase.cs
@@ -23,7 +23,7 @@ public class MemberDependencyTestBase
     protected static CSharpCompilation CompilationFor(params string[] code)
     {
         var syntaxTrees = code.Select(source => CSharpSyntaxTree.ParseText(source));
-        var comp = CSharpCompilation.Create("Test", syntaxTrees, Basic.Reference.Assemblies.Net80.References.All, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var comp = CSharpCompilation.Create("Test", syntaxTrees, Basic.Reference.Assemblies.Net90.References.All, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         
         var errors = comp.GetDiagnostics()
             .Where(d => d.Severity == DiagnosticSeverity.Error)

--- a/Cecilifier.Core.Tests/Tests/Unit/MethodExtensionsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MethodExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Cecilifier.Core.Extensions;
 using Cecilifier.Core.Tests.Tests.Unit.Framework;
@@ -42,7 +43,7 @@ internal class MethodExtensionsTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
 
-        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.TestScenario");
+        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.TestScenario").EnsureNotNull();
         var testMethod = testType.GetMembers("UseNestedType").Single().EnsureNotNull<ISymbol, IMethodSymbol>();
 
         var resolvedMethod = testMethod.MethodResolverExpression(context);
@@ -54,7 +55,7 @@ internal class MethodExtensionsTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
 
-        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.SomeClass`1");
+        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.SomeClass`1").EnsureNotNull();
         var testMethod = testType.GetMembers("Overload1").OfType<IMethodSymbol>().First(m => m.Parameters.Length == 2).EnsureNotNull<ISymbol, IMethodSymbol>();
 
         var resolvedMethod = testMethod.MethodResolverExpression(context);
@@ -79,7 +80,7 @@ internal class MethodExtensionsTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
 
-        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.SomeClass`1");
+        var testType = context.SemanticModel.Compilation.GetTypeByMetadataName("Cecilifier.Core.Tests.Tests.Unit.SomeClass`1").EnsureNotNull();
         var testMethod = testType.GetMembers("Overload2").OfType<IMethodSymbol>().First(m => m.Parameters.Length == 2).EnsureNotNull<ISymbol, IMethodSymbol>();
 
         var resolvedMethod = testMethod.MethodResolverExpression(context);

--- a/Cecilifier.Core.Tests/Tests/Unit/PrivateImplementationDetailsGeneratorTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/PrivateImplementationDetailsGeneratorTests.cs
@@ -167,7 +167,6 @@ public class PrivateImplementationDetailsGeneratorTests
 
         static TestCaseData TestCaseDataFor<T>(Expression<Func<T[]>> expression, FieldInfo[] fields)
         {
-            Boolean b;
             var fieldExpression = (MemberExpression) expression.Body;
             var fieldName = fieldExpression.Member.Name.AsSpan();
             var sizeSeparatorIndex = fieldName.IndexOf('_');

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeResolverTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeResolverTests.cs
@@ -49,7 +49,7 @@ internal class TypeResolverTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
         var m1Syntax = GetMethodSyntax(context, "M1"); // Func<T> M1() {}
-        var m1Symbol = context.SemanticModel.GetDeclaredSymbol(m1Syntax);
+        var m1Symbol = context.SemanticModel.GetDeclaredSymbol(m1Syntax).EnsureNotNull();
 
         // Simulates type parameter `T` being registered under type `Foo`
         using var _ = context.DefinitionVariables.WithCurrent("Foo<T>", "T", VariableMemberKind.TypeParameter, "TypeParameter_T_var");
@@ -63,7 +63,7 @@ internal class TypeResolverTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
         var methodSyntax = GetMethodSyntax(context, "M2"); // Func<TM> M2<TM>() {}
-        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
+        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax).EnsureNotNull();
 
         // Simulates type parameter `T` being registered under method `M2`
         using var _ = context.DefinitionVariables.WithCurrent("Foo<T>.M2<TM>()", "TM", VariableMemberKind.TypeParameter, "TypeParameter_TM_var");
@@ -77,7 +77,7 @@ internal class TypeResolverTests : CecilifierContextBasedTestBase
     {
         var context = NewContext();
         var methodSyntax = GetMethodSyntax(context, "M3"); // Func<T, TM> M3<TM>() {}
-        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
+        var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax).EnsureNotNull();
 
         // Simulates type parameters `T` & `TM` being registered under their respective members.
         using var t = context.DefinitionVariables.WithCurrent("Foo<T>", "T", VariableMemberKind.TypeParameter, "TypeParameter_Foo");

--- a/Cecilifier.Core/AST/BinaryOperatorHandler.cs
+++ b/Cecilifier.Core/AST/BinaryOperatorHandler.cs
@@ -44,18 +44,14 @@ internal sealed class BinaryOperatorHandler
     
     public void ProcessRaw(IVisitorContext context, string ilVar, ExpressionSyntax left, ExpressionSyntax right)
     {
-        ThrowIfRawHandlerIsNull();
+        if (_rawHandler == null) 
+            throw new InvalidOperationException("The constructor taking two ITypeSymbols should be used to initialize this instance.");
+        
         _rawHandler(
             context, 
             ilVar, 
             context.SemanticModel.GetTypeInfo(left).Type, 
             context.SemanticModel.GetTypeInfo(right).Type);
-
-        [ExcludeFromCodeCoverage]
-        void ThrowIfRawHandlerIsNull()
-        {
-            if (_rawHandler == null) throw new InvalidOperationException("The constructor taking two ITypeSymbols should be used to initialize this instance.");
-        }
     }
 
     public BinaryOperatorHandler(Action<IVisitorContext, string, BinaryExpressionSyntax, ExpressionVisitor> handler)
@@ -66,7 +62,7 @@ internal sealed class BinaryOperatorHandler
 
     private BinaryOperatorHandler(Action<IVisitorContext, string, ITypeSymbol, ITypeSymbol> action, bool visitRightOperand)
     {
-        _rawHandler = action;
+        _rawHandler = action!;
         _visitRightOperand = visitRightOperand;
     }
     

--- a/Cecilifier.Core/AST/CecilExpressionFactory.cs
+++ b/Cecilifier.Core/AST/CecilExpressionFactory.cs
@@ -8,7 +8,7 @@ internal static class CecilExpressionFactory
 {
     public static void EmitThrow(IVisitorContext context, string ilVar, ExpressionSyntax expression)
     {
-        var _ = LineInformationTracker.Track(context, expression);
+        _ = LineInformationTracker.Track(context, expression);
         ExpressionVisitor.Visit(context, ilVar, expression);
         context.EmitCilInstruction(ilVar, OpCodes.Throw);
     }

--- a/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
+++ b/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
@@ -10,7 +10,6 @@ using Cecilifier.Core.Misc;
 using Cecilifier.Core.Naming;
 using Cecilifier.Core.Variables;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Mono.Cecil.Cil;

--- a/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
+++ b/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
@@ -188,8 +188,8 @@ internal static class CollectionExpressionProcessor
         if (ctors.Count() == 1)
             return ctors.First().MethodResolverExpression(context);
 
-        var expectedParamTypes = ctorParamTypes.Select(paramType => context.SemanticModel.Compilation.GetTypeByMetadataName(paramType.FullName!)).ToHashSet();
-        return ctors.Single(ctor => !ctor.Parameters.Select(p => p.Type).ToHashSet().Except(expectedParamTypes, SymbolEqualityComparer.Default).Any()).MethodResolverExpression(context);
+        var expectedParamTypes = ctorParamTypes.Select(paramType => context.SemanticModel.Compilation.GetTypeByMetadataName(paramType.FullName!)).ToHashSet(SymbolEqualityComparer.Default);
+        return ctors.Single(ctor => !ctor.Parameters.Select(p => p.Type).ToHashSet(SymbolEqualityComparer.Default).Except(expectedParamTypes, SymbolEqualityComparer.Default).Any()).MethodResolverExpression(context);
     }
 
     private static void HandleAssignmentToArray(ExpressionVisitor visitor, CollectionExpressionSyntax node, IArrayTypeSymbol arrayTypeSymbol)

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Mono.Cecil.Cil;
 using static Cecilifier.Core.Misc.CodeGenerationHelpers;
 
+#nullable enable
 namespace Cecilifier.Core.AST
 {
     internal partial class ExpressionVisitor : SyntaxWalkerBase
@@ -43,7 +44,7 @@ namespace Cecilifier.Core.AST
         ///  
         /// In this scenario, '_lastInstructionLoadingTargetOfInvocation' will point to IL1 when processing
         /// the call to M1() and to IL5 when processing the call to M2()
-        private LinkedListNode<string> _lastInstructionLoadingTargetOfInvocation;
+        private LinkedListNode<string>? _lastInstructionLoadingTargetOfInvocation;
 
         static ExpressionVisitor()
         {
@@ -229,7 +230,7 @@ namespace Cecilifier.Core.AST
                 // `ImplicitArrayCreationExpressionSyntax` is not a parent of the initializer expression, 
                 // which means, VisitImplicitArrayCreationExpression() will not be called
                 // https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/single-dimensional-arrays
-                ProcessImplicitArrayCreationExpression(node, Context.GetTypeInfo(node).ConvertedType);
+                ProcessImplicitArrayCreationExpression(node, Context.GetTypeInfo(node).ConvertedType.EnsureNotNull<ITypeSymbol, ITypeSymbol>());
             }
             else if (node.IsKind(SyntaxKind.CollectionInitializerExpression))
             {
@@ -272,7 +273,7 @@ namespace Cecilifier.Core.AST
         public override void VisitImplicitArrayCreationExpression(ImplicitArrayCreationExpressionSyntax node)
         {
             using var _ = LineInformationTracker.Track(Context, node);
-            ProcessImplicitArrayCreationExpression(node.Initializer, Context.GetTypeInfo(node).Type);
+            ProcessImplicitArrayCreationExpression(node.Initializer, Context.GetTypeInfo(node).Type!);
         }
 
         public override void VisitElementAccessExpression(ElementAccessExpressionSyntax node)
@@ -282,7 +283,7 @@ namespace Cecilifier.Core.AST
             if (expressionInfo.Symbol == null)
                 return;
 
-            var targetType = expressionInfo.Symbol.Accept(ElementTypeSymbolResolver.Instance);
+            var targetType = expressionInfo.Symbol.Accept(ElementTypeSymbolResolver.Instance)!;
             if (SymbolEqualityComparer.Default.Equals(targetType.OriginalDefinition, Context.RoslynTypeSystem.SystemSpan)
                 && node.ArgumentList.Arguments.Count == 1
                 && SymbolEqualityComparer.Default.Equals(Context.GetTypeInfo(node.ArgumentList.Arguments[0].Expression).Type, Context.RoslynTypeSystem.SystemRange))
@@ -427,7 +428,7 @@ namespace Cecilifier.Core.AST
         {
             using var _ = LineInformationTracker.Track(Context, node);
 
-            var literalParent = (CSharpSyntaxNode) node.Parent;
+            var literalParent = (CSharpSyntaxNode) node.Parent!;
             Debug.Assert(literalParent != null);
 
             var nodeType = Context.SemanticModel.GetTypeInfo(node);
@@ -444,7 +445,7 @@ namespace Cecilifier.Core.AST
                 _ => node.Token.Text
             };
 
-            literalType ??= Context.SemanticModel.GetTypeInfo(literalParent).Type;
+            literalType ??= Context.SemanticModel.GetTypeInfo(literalParent).Type!;
             LoadLiteralValue(ilVar,
                 literalType,
                 value,
@@ -459,7 +460,7 @@ namespace Cecilifier.Core.AST
             using var _ = LineInformationTracker.Track(Context, node);
             if (node.Parent is ArgumentSyntax argument && argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword))
             {
-                var localSymbol = (ILocalSymbol) Context.SemanticModel.GetSymbolInfo(node).Symbol;
+                var localSymbol = Context.SemanticModel.GetSymbolInfo(node).Symbol.EnsureNotNull<ISymbol, ILocalSymbol>();
                 var designation = ((SingleVariableDesignationSyntax) node.Designation);
                 var resolvedOutArgType = Context.TypeResolver.Resolve(localSymbol.Type);
 
@@ -688,7 +689,7 @@ namespace Cecilifier.Core.AST
         {
             var ctorInfo = Context.SemanticModel.GetSymbolInfo(node);
 
-            var ctor = (IMethodSymbol) ctorInfo.Symbol;
+            var ctor = (IMethodSymbol?) ctorInfo.Symbol;
             if (ctor == null)
             {
                 if (TryProcessTypeParameterInstantiation(node))
@@ -824,8 +825,8 @@ namespace Cecilifier.Core.AST
         {
             using var _ = LineInformationTracker.Track(Context, node);
 
-            VisitIndex(node.LeftOperand);
-            VisitIndex(node.RightOperand);
+            VisitIndex(node.LeftOperand!);
+            VisitIndex(node.RightOperand!);
 
             var indexType = Context.RoslynTypeSystem.SystemIndex;
             var rangeCtor = Context.RoslynTypeSystem.SystemRange
@@ -905,7 +906,7 @@ namespace Cecilifier.Core.AST
         {
             using var _ = LineInformationTracker.Track(Context, node);
 
-            var varType = Context.TypeResolver.Resolve(Context.SemanticModel.GetTypeInfo(node.Type).Type);
+            var varType = Context.TypeResolver.Resolve(Context.SemanticModel.GetTypeInfo(node.Type!).Type);
             string localVarName = LocalVariableNameOrDefault(node, "tmp");
             var localVar = Context.AddLocalVariableToCurrentMethod(localVarName, varType).VariableName;
 
@@ -917,12 +918,12 @@ namespace Cecilifier.Core.AST
             Context.EmitCilInstruction(ilVar, OpCodes.Brfalse_S, typeDoesNotMatchVar);
 
             // Compares each sub-pattern
-            foreach (var pattern in node.PropertyPatternClause.Subpatterns)
+            foreach (var pattern in node.PropertyPatternClause!.Subpatterns)
             {
                 Context.EmitCilInstruction(ilVar, OpCodes.Ldloc, localVar);
                 pattern.Accept(this);
 
-                var comparisonType = Context.SemanticModel.GetSymbolInfo(pattern.NameColon?.Name ?? pattern.ExpressionColon?.Expression).Symbol.GetMemberType();
+                var comparisonType = Context.SemanticModel.GetSymbolInfo(pattern.NameColon?.Name ?? pattern.ExpressionColon?.Expression!).Symbol.GetMemberType();
                 var opEquality = comparisonType.GetMembers().FirstOrDefault(m => m.Kind == SymbolKind.Method && m.Name == "op_Equality");
                 if (opEquality != null)
                 {
@@ -1051,7 +1052,7 @@ namespace Cecilifier.Core.AST
                 Context.EmitCilInstruction(ilVar, opCode);
             }
 
-            ITypeSymbol type = Context.SemanticModel.GetTypeInfo(operand).Type;
+            var type = Context.SemanticModel.GetTypeInfo(operand).Type;
             var tempLocalName = StoreTopOfStackInLocalVariable(Context, ilVar, "tmp", type).VariableName;
             
             Context.EmitCilInstruction(ilVar, OpCodes.Ldloc, tempLocalName);
@@ -1147,7 +1148,7 @@ namespace Cecilifier.Core.AST
             var parentElementAccessExpression = node.Ancestors().OfType<ElementAccessExpressionSyntax>().FirstOrDefault(candidate => candidate.ArgumentList.Contains(node));
             if (parentElementAccessExpression != null)
             {
-                ITypeSymbol type = Context.SemanticModel.GetTypeInfo(node).Type;
+                var type = Context.SemanticModel.GetTypeInfo(node).Type;
                 var tempLocal = StoreTopOfStackInLocalVariable(Context, ilVar, "tmpIndex", type).VariableName;
                 Context.EmitCilInstruction(ilVar, OpCodes.Ldloca, tempLocal);
             }
@@ -1162,7 +1163,7 @@ namespace Cecilifier.Core.AST
             var indexedType = Context.SemanticModel.GetTypeInfo(elementAccessExpressionSyntax.Expression).Type.EnsureNotNull();
             if (indexedType.Name == "Span")
             {
-                IMethodSymbol method = ((IPropertySymbol) indexedType.GetMembers("Length").Single()).GetMethod;
+                var method = indexedType.GetMembers("Length").Single().EnsureNotNull<ISymbol, IPropertySymbol>().GetMethod;
                 Context.AddCallToMethod(method, ilVar, MethodDispatchInformation.MostLikelyVirtual);
             }
             else
@@ -1232,7 +1233,7 @@ namespace Cecilifier.Core.AST
                 || IsObjectCreationExpressionUsedAsSourceOfCast(node)
                 || IsObjectCreationExpressionUsedAsInParameter(node)
                 || IsSimpleMethodInvocation(node))
-                StoreTopOfStackInLocalVariableAndLoad(node, targetOfInvocationType.Type);
+                StoreTopOfStackInLocalVariableAndLoad(node, targetOfInvocationType.Type!);
         }
 
         private static bool IsLeftHandSideOfMemberAccessExpression(ExpressionSyntax toBeChecked)
@@ -1270,13 +1271,13 @@ namespace Cecilifier.Core.AST
             }
 
             var parentMae = expressionSyntax.FirstAncestorOrSelf<MemberAccessExpressionSyntax>(ancestor => ancestor.Kind() == SyntaxKind.SimpleMemberAccessExpression);
-            if (parentMae != null && SymbolEqualityComparer.Default.Equals(Context.SemanticModel.GetSymbolInfo(parentMae).Symbol.ContainingType, Context.RoslynTypeSystem.SystemValueType))
+            if (parentMae != null && SymbolEqualityComparer.Default.Equals(Context.SemanticModel.GetSymbolInfo(parentMae).Symbol!.ContainingType, Context.RoslynTypeSystem.SystemValueType))
             {
                 // it is a reference on a value type to a method defined in System.ValueType (GetHashCode(), ToString(), etc)
                 Context.SetFlag(Constants.ContextFlags.MemberReferenceRequiresConstraint, Context.TypeResolver.Resolve(type));
             }
 
-            bool RequiresAddressOfValue() => IsObjectCreationExpressionUsedAsInParameter(expressionSyntax) || expressionSyntax.Parent.FirstAncestorOrSelf<SyntaxNode>(c => !c.IsKind(SyntaxKind.ParenthesizedExpression)).IsKind(SyntaxKind.SimpleMemberAccessExpression);
+            bool RequiresAddressOfValue() => IsObjectCreationExpressionUsedAsInParameter(expressionSyntax) || expressionSyntax.Parent!.FirstAncestorOrSelf<SyntaxNode>(c => !c.IsKind(SyntaxKind.ParenthesizedExpression)).IsKind(SyntaxKind.SimpleMemberAccessExpression);
         }
         
         private void FixCallSite()
@@ -1358,12 +1359,12 @@ namespace Cecilifier.Core.AST
             var delegateType = firstParentNotPartOfName switch
             {
                 // assumes that a method reference in an object creation expression can only be a delegate instantiation.
-                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.ObjectCreationExpression } arg => Context.SemanticModel.GetTypeInfo(arg.Parent.Parent).Type,
+                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.ObjectCreationExpression } arg => Context.SemanticModel.GetTypeInfo(arg.Parent!.Parent!).Type,
 
                 // assumes that a method reference in an invocation expression is method group -> delegate conversion. 
-                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.InvocationExpression } arg => ((IMethodSymbol) Context.SemanticModel.GetSymbolInfo(arg.Parent.Parent).Symbol).Parameters[arg.FirstAncestorOrSelf<ArgumentListSyntax>().Arguments.IndexOf(arg)].Type,
+                ArgumentSyntax { Parent.Parent.RawKind: (int) SyntaxKind.InvocationExpression } arg => ((IMethodSymbol) Context.SemanticModel.GetSymbolInfo(arg.Parent!.Parent!).Symbol!).Parameters[arg.FirstAncestorOrSelf<ArgumentListSyntax>()!.Arguments.IndexOf(arg)].Type,
 
-                AssignmentExpressionSyntax assignment => Context.SemanticModel.GetSymbolInfo(assignment.Left).Symbol.Accept(ElementTypeSymbolResolver.Instance),
+                AssignmentExpressionSyntax assignment => Context.SemanticModel.GetSymbolInfo(assignment.Left).Symbol!.Accept(ElementTypeSymbolResolver.Instance),
 
                 VariableDeclarationSyntax variableDeclaration => Context.SemanticModel.GetTypeInfo(variableDeclaration.Type).Type,
 
@@ -1451,7 +1452,7 @@ namespace Cecilifier.Core.AST
 		 * 
 		 * To fix this we visit in the order [exp, args] and move the call operation after visiting the arguments
 		 */
-        private void HandleMethodInvocation(SyntaxNode target, ArgumentListSyntax args, ISymbol method = null)
+        private void HandleMethodInvocation(SyntaxNode target, ArgumentListSyntax args, ISymbol? method = null)
         {
             var targetTypeInfo = Context.SemanticModel.GetTypeInfo(target).Type;
             if (targetTypeInfo?.TypeKind == TypeKind.FunctionPointer)
@@ -1467,6 +1468,7 @@ namespace Cecilifier.Core.AST
                 var callContext = (FirstInstruction: _lastInstructionLoadingTargetOfInvocation, LastInstruction: Context.CurrentLine);
 
                 StackallocAsArgumentFixer.Current?.MarkEndOfComputedCallTargetBlock(callContext.FirstInstruction);
+                Debug.Assert(method != null);
                 ProcessArgumentsTakingDefaultParametersIntoAccount(method, args);
                 
                 if (callContext.FirstInstruction != null)
@@ -1498,7 +1500,7 @@ namespace Cecilifier.Core.AST
         {
             if (arg.TryGetAttribute<CallerArgumentExpressionAttribute>(out var callerArgumentExpressionAttribute))
             {
-                var expressionParameter = parameters.SingleOrDefault(p => p.Name == (string) callerArgumentExpressionAttribute.ConstructorArguments[0].Value);
+                var expressionParameter = parameters.SingleOrDefault(p => p.Name == (string) callerArgumentExpressionAttribute.ConstructorArguments[0].Value!);
                 if (expressionParameter != null)
                     return arguments[expressionParameter.Ordinal].Expression.ToFullString();
             }
@@ -1510,10 +1512,11 @@ namespace Cecilifier.Core.AST
         {
             using var trackIfNotPartOfTypeName = LineInformationTracker.Track(Context, node);
             var member = Context.SemanticModel.GetSymbolInfo(node);
+            Debug.Assert(member.Symbol != null);
             switch (member.Symbol.Kind)
             {
                 case SymbolKind.Method:
-                    ProcessMethodReference(node, member.Symbol as IMethodSymbol);
+                    ProcessMethodReference(node, (IMethodSymbol) member.Symbol);
                     trackIfNotPartOfTypeName.Discard(); // for methods it is better to use the whole invocation expression.
                     break;
 
@@ -1530,7 +1533,7 @@ namespace Cecilifier.Core.AST
                     break;
 
                 case SymbolKind.Property:
-                    ProcessProperty(node, member.Symbol as IPropertySymbol);
+                    ProcessProperty(node, (IPropertySymbol) member.Symbol);
                     break;
 
                 case SymbolKind.TypeParameter:
@@ -1545,16 +1548,16 @@ namespace Cecilifier.Core.AST
 
         private void ProcessImplicitArrayCreationExpression(InitializerExpressionSyntax initializer, ITypeSymbol typeSymbol)
         {
-            var arrayType = typeSymbol.EnsureNotNull<ITypeSymbol, IArrayTypeSymbol>($"Unable to infer array type from {initializer.Parent}");
+            var arrayType = typeSymbol.EnsureNotNull<ITypeSymbol, IArrayTypeSymbol>();
             Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, initializer.Expressions.Count);
             ProcessArrayCreation(arrayType.ElementType, initializer);
         }
 
-        private void ProcessArrayCreation(ITypeSymbol elementType, InitializerExpressionSyntax initializer)
+        private void ProcessArrayCreation(ITypeSymbol elementType, InitializerExpressionSyntax? initializer)
         {
             AddCilInstruction(ilVar, OpCodes.Newarr, elementType);
             if (PrivateImplementationDetailsGenerator.IsApplicableTo(initializer, Context))
-                ArrayInitializationProcessor.InitializeOptimized(this, elementType, initializer.Expressions);
+                ArrayInitializationProcessor.InitializeOptimized(this, elementType, initializer!.Expressions);
             else
                 ArrayInitializationProcessor.InitializeUnoptimized(this, elementType, initializer?.Expressions, initializer != null ? Context.SemanticModel.GetOperation(initializer) : null);
         }
@@ -1598,37 +1601,37 @@ namespace Cecilifier.Core.AST
     {
         public static ElementTypeSymbolResolver Instance = new ElementTypeSymbolResolver();
 
-        public override ITypeSymbol VisitEvent(IEventSymbol symbol)
+        public override ITypeSymbol? VisitEvent(IEventSymbol symbol)
         {
             return symbol.Type.Accept(this);
         }
 
-        public override ITypeSymbol VisitField(IFieldSymbol symbol)
+        public override ITypeSymbol? VisitField(IFieldSymbol symbol)
         {
             return symbol.Type.Accept(this);
         }
 
-        public override ITypeSymbol VisitLocal(ILocalSymbol symbol)
+        public override ITypeSymbol? VisitLocal(ILocalSymbol symbol)
         {
             return symbol.Type.Accept(this);
         }
 
-        public override ITypeSymbol VisitMethod(IMethodSymbol symbol)
+        public override ITypeSymbol? VisitMethod(IMethodSymbol symbol)
         {
             return symbol.ReturnType.Accept(this);
         }
 
-        public override ITypeSymbol VisitProperty(IPropertySymbol symbol)
+        public override ITypeSymbol? VisitProperty(IPropertySymbol symbol)
         {
             return symbol.Type.Accept(this);
         }
 
-        public override ITypeSymbol VisitParameter(IParameterSymbol symbol)
+        public override ITypeSymbol? VisitParameter(IParameterSymbol symbol)
         {
             return symbol.Type.Accept(this);
         }
 
-        public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)
+        public override ITypeSymbol? VisitArrayType(IArrayTypeSymbol symbol)
         {
             return symbol.ElementType;
         }

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -1451,7 +1451,7 @@ namespace Cecilifier.Core.AST
 		 * 
 		 * To fix this we visit in the order [exp, args] and move the call operation after visiting the arguments
 		 */
-        private void HandleMethodInvocation(SyntaxNode target, ArgumentListSyntax args, ISymbol? method = null)
+        private void HandleMethodInvocation(SyntaxNode target, ArgumentListSyntax args, ISymbol method = null)
         {
             var targetTypeInfo = Context.SemanticModel.GetTypeInfo(target).Type;
             if (targetTypeInfo?.TypeKind == TypeKind.FunctionPointer)
@@ -1482,7 +1482,7 @@ namespace Cecilifier.Core.AST
             _lastInstructionLoadingTargetOfInvocation = Context.CurrentLine;
         }
         
-        private void ProcessArgumentsTakingDefaultParametersIntoAccount(ISymbol? method, ArgumentListSyntax args)
+        private void ProcessArgumentsTakingDefaultParametersIntoAccount(ISymbol method, ArgumentListSyntax args)
         {
             Visit(args);
             if (method is not IMethodSymbol methodSymbol || methodSymbol.Parameters.Length <= args.Arguments.Count)

--- a/Cecilifier.Core/AST/MemberDependencies/IMemberDependencyFactory.cs
+++ b/Cecilifier.Core/AST/MemberDependencies/IMemberDependencyFactory.cs
@@ -1,8 +1,9 @@
 using Microsoft.CodeAnalysis.CSharp;
 
+#nullable enable
 namespace Cecilifier.Core.AST.MemberDependencies;
 
-internal interface IMemberDependencyFactory<T> where T : MemberDependency
+internal interface IMemberDependencyFactory<out T> where T : MemberDependency
 {
-    public static abstract T CreateInstance(CSharpSyntaxNode syntaxNode);
+    public static abstract T CreateInstance(CSharpSyntaxNode? syntaxNode);
 }

--- a/Cecilifier.Core/AST/MemberDependencies/MemberDependency.cs
+++ b/Cecilifier.Core/AST/MemberDependencies/MemberDependency.cs
@@ -1,18 +1,20 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 
+#nullable enable
+
 namespace Cecilifier.Core.AST.MemberDependencies;
 
 internal record MemberDependency : IMemberDependencyFactory<MemberDependency>
 {
-    public CSharpSyntaxNode Declaration { get; set; }
+    public CSharpSyntaxNode? Declaration { get; set; }
 
     public void AddReference(MemberDependency dependency)
     {
         _dependencies.Add(dependency);
     }
     
-    public static MemberDependency CreateInstance(CSharpSyntaxNode node) => new() { Declaration = node };
+    public static MemberDependency CreateInstance(CSharpSyntaxNode? node) => new() { Declaration = node };
     public IReadOnlyList<MemberDependency> Dependencies => _dependencies;
 
     public void Accept(IMemberDependencyVisitor<MemberDependency> visitor)

--- a/Cecilifier.Core/AST/NullLiteralArgumentDecorator.cs
+++ b/Cecilifier.Core/AST/NullLiteralArgumentDecorator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading;
 using Cecilifier.Core.Extensions;
 using Microsoft.CodeAnalysis;
@@ -21,13 +22,13 @@ namespace Cecilifier.Core.AST;
 /// </remarks>
 internal ref struct  NullLiteralArgumentDecorator
 {
-    private string? _localVariableName;
-    private readonly IVisitorContext? _context;
-    private readonly string? _ilVar;
+    private string _localVariableName;
+    private readonly IVisitorContext _context;
+    private readonly string _ilVar;
         
     public NullLiteralArgumentDecorator(IVisitorContext context, ArgumentSyntax node, string ilVar)
     {
-        if (node.Expression is not LiteralExpressionSyntax { RawKind: (int) SyntaxKind.NullLiteralExpression } nullLiteralExpression)
+        if (node.Expression is not LiteralExpressionSyntax { RawKind: (int) SyntaxKind.NullLiteralExpression })
             return;
             
         var argType = context.SemanticModel.GetTypeInfo(node.Expression).ConvertedType.EnsureNotNull();
@@ -50,6 +51,8 @@ internal ref struct  NullLiteralArgumentDecorator
         string localVariable = Interlocked.Exchange(ref _localVariableName, null);
         if (localVariable != null)
         {
+            Debug.Assert(_context != null);
+            Debug.Assert(_ilVar != null);
             _context!.EmitCilInstruction(_ilVar, OpCodes.Ldloc_S, localVariable);
         }
     }

--- a/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
@@ -303,7 +303,7 @@ namespace Cecilifier.Core.AST
         private static string BackingFieldModifiersFor(BasePropertyDeclarationSyntax node)
         {
             var m = node.Modifiers.ExceptBy(
-                [SyntaxKind.PublicKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword, SyntaxKind.VirtualKeyword, SyntaxKind.OverrideKeyword],
+                [SyntaxKind.PublicKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword, SyntaxKind.VirtualKeyword, SyntaxKind.OverrideKeyword, SyntaxKind.PartialKeyword],
                 c => c.Kind());
             
             if (node.AccessorList != null && node.AccessorList.Accessors.Any(acc => acc.IsKind(SyntaxKind.InitAccessorDeclaration)))

--- a/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
@@ -202,7 +202,7 @@ namespace Cecilifier.Core.AST
                 }
                 else
                 {
-                    ExpressionVisitor.Visit(Context, ilSetVar, accessor.ExpressionBody);
+                    ExpressionVisitor.Visit(Context, ilSetVar, accessor.ExpressionBody!);
                 }
 
                 Context.EmitCilInstruction(ilSetVar, OpCodes.Ret);
@@ -262,7 +262,7 @@ namespace Cecilifier.Core.AST
 
             void ProcessExpressionBodiedGetter(string ilVar, ArrowExpressionClauseSyntax? expression)
             {
-                ExpressionVisitor.Visit(Context, ilVar, expression);
+                ExpressionVisitor.Visit(Context, ilVar, expression!);
                 Context.EmitCilInstruction(ilVar, OpCodes.Ret);
             }
         }

--- a/Cecilifier.Core/AST/StatementVisitor.TryCatchFinally.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.TryCatchFinally.cs
@@ -5,11 +5,12 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Mono.Cecil.Cil;
 
+#nullable enable annotations
 namespace Cecilifier.Core.AST
 {
     internal partial class StatementVisitor
     {
-        private void ProcessTryCatchFinallyBlock<TState>(string ilVar, CSharpSyntaxNode tryStatement, CatchClauseSyntax[] catches, Action<TState> finallyBlockHandler, TState state = default)
+        private void ProcessTryCatchFinallyBlock<TState>(string ilVar, CSharpSyntaxNode tryStatement, CatchClauseSyntax[] catches, Action<TState>? finallyBlockHandler, TState state = default)
         {
             ProcessWithInTryCatchFinallyBlock(ilVar, _ => tryStatement.Accept(this), catches, finallyBlockHandler, state);
         }

--- a/Cecilifier.Core/AST/StatementVisitor.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Cecilifier.Core.Extensions;
 using Cecilifier.Core.Mappings;
@@ -12,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Mono.Cecil.Cil;
 using static Cecilifier.Core.Misc.CodeGenerationHelpers;
 
+#nullable enable annotations
 namespace Cecilifier.Core.AST
 {
     internal partial class StatementVisitor : SyntaxWalkerBase
@@ -257,6 +259,8 @@ namespace Cecilifier.Core.AST
 
             void FinallyBlockHandler(ForEachHandlerContext _)
             {
+                Debug.Assert(usingType != null);
+                
                 string? lastFinallyInstructionLabel = null;
                 if (usingType.TypeKind == TypeKind.TypeParameter || usingType.IsValueType)
                 {

--- a/Cecilifier.Core/AST/StatementVisitor.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.cs
@@ -56,7 +56,7 @@ namespace Cecilifier.Core.AST
 
             Context.WriteComment($"for condition: {node.Condition.HumanReadableSummary()}");
             // Condition
-            ExpressionVisitor.Visit(Context, _ilVar, node.Condition);
+            ExpressionVisitor.Visit(Context, _ilVar, node.Condition!);
             Context.EmitCilInstruction(_ilVar, OpCodes.Brfalse, forEndLabel);
 
             // Body
@@ -241,7 +241,7 @@ namespace Cecilifier.Core.AST
         {
             //https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/statements.md#1214-the-using-statement
 
-            ExpressionVisitor.Visit(Context, _ilVar, node.Expression);
+            ExpressionVisitor.Visit(Context, _ilVar, node.Expression!);
             string localVarDef;
 
             ITypeSymbol usingType;

--- a/Cecilifier.Core/Cecilifier.Core.csproj
+++ b/Cecilifier.Core/Cecilifier.Core.csproj
@@ -5,4 +5,33 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests"/>
   </ItemGroup>
+  
+  <Target Name="Generate" BeforeTargets="CoreCompile">
+    <Exec Command="git log -1 --pretty=format:%H" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitRevision" />
+    </Exec>
+
+    <PropertyGroup>
+      <BuildInformationPartialCode>
+        namespace Cecilifier.Core.Misc%3B
+        
+        public static partial class BuildInformation
+        {
+        public static partial string GitRevision() => "$(GitRevision)"%3B
+        public static partial string BuildDate() => "$([System.DateTime]::Now)"%3B
+        }
+      </BuildInformationPartialCode>
+      
+      <BuildInformationPartialFilePath>$(IntermediateOutputPath)BuildInformationPartialCode.g.cs</BuildInformationPartialFilePath>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+            File="$(BuildInformationPartialFilePath)"
+            Overwrite="true"
+            Lines="$(BuildInformationPartialCode)" />
+
+    <ItemGroup>
+      <Compile Include="$(BuildInformationPartialFilePath)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Cecilifier.Core/Cecilifier.cs
+++ b/Cecilifier.Core/Cecilifier.cs
@@ -15,7 +15,7 @@ namespace Cecilifier.Core
     {
         internal const int CecilifierProgramPreambleLength = 25; // The # of lines before the 1st cecilified line of code (see CecilifierExtensions.AsCecilApplication())
 
-        private const LanguageVersion CurrentLanguageVersion = LanguageVersion.CSharp12;
+        private const LanguageVersion CurrentLanguageVersion = LanguageVersion.CSharp13;
         public static readonly int SupportedCSharpVersion = int.Parse(CurrentLanguageVersion.ToString().Substring("CSharp".Length));
 
         public static CecilifierResult Process(Stream content, CecilifierOptions options)

--- a/Cecilifier.Core/Extensions/ExpressionExtensions.cs
+++ b/Cecilifier.Core/Extensions/ExpressionExtensions.cs
@@ -161,7 +161,7 @@ namespace Cecilifier.Core.Extensions
             return _context.TypeResolver.Resolve(typeSymbol.Type);
         }
 
-        public override string? VisitInvocationExpression(InvocationExpressionSyntax node)
+        public override string VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             if (node.Expression is IdentifierNameSyntax { Identifier.Text: "nameof" } )
             {

--- a/Cecilifier.Core/Extensions/SyntaxNodeExtensions.cs
+++ b/Cecilifier.Core/Extensions/SyntaxNodeExtensions.cs
@@ -121,7 +121,7 @@ namespace Cecilifier.Core.Extensions
 
         #nullable enable
         [return: NotNull]
-        public static TTarget EnsureNotNull<TSource, TTarget>([NotNullIfNotNull("source")] this TSource? source, [CallerArgumentExpression("source")] string exp = null) where TTarget : TSource
+        public static TTarget EnsureNotNull<TSource, TTarget>([NotNullIfNotNull("source")] this TSource? source, [CallerArgumentExpression("source")] string? exp = null) where TTarget : TSource
         {
             if (source == null)
                 throw new ArgumentNullException(exp);

--- a/Cecilifier.Core/Misc/BuildInformation.cs
+++ b/Cecilifier.Core/Misc/BuildInformation.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Cecilifier.Core.Misc;
+
+public static partial class BuildInformation
+{
+    public static partial string GitRevision();
+    public static partial string BuildDate();
+}

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -403,12 +403,12 @@ namespace Cecilifier.Core.Misc
             for (int i = 0; i < typeParamList.Count; i++)
             {
                 exps.Add($"{memberDefVar}.GenericParameters.Add({genericTypeParamEntries[i].genParamDefVar});");
-                AddConstraints(genericTypeParamEntries[i].genParamDefVar, genericTypeParamEntries[i].typeParameterSymbol);
+                AddConstraints(genericTypeParamEntries[i].genParamDefVar, genericTypeParamEntries[i].typeParameterSymbol, typeParamList[i]);
             }
 
             ArrayPool<(string genParamDefVar, ITypeParameterSymbol typeParameterSymbol)>.Shared.Return(genericTypeParamEntries);
 
-            void AddConstraints(string genParamDefVar, ITypeParameterSymbol typeParam)
+            void AddConstraints(string genParamDefVar, ITypeParameterSymbol typeParam, TypeParameterSyntax typeParameterSyntax)
             {
                 if (typeParam.HasConstructorConstraint || typeParam.HasValueTypeConstraint) // struct constraint implies new()
                 {
@@ -438,6 +438,10 @@ namespace Cecilifier.Core.Misc
                 else if (typeParam.Variance == VarianceKind.Out)
                 {
                     exps.Add($"{genParamDefVar}.IsCovariant = true;");
+                }
+                else if (typeParam.AllowsRefLikeType)
+                {
+                    context.EmitWarning("`allow ref struct` feature is not implemented yet.", typeParameterSyntax);
                 }
 
                 //https://github.com/adrianoc/cecilifier/issues/312

--- a/Cecilifier.Core/Misc/NameSyntaxExtensions.cs
+++ b/Cecilifier.Core/Misc/NameSyntaxExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+#nullable enable annotations
+
 namespace Cecilifier.Core.Misc
 {
     public static class NameSyntaxExtensions

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>11</LangVersion>
-    <AssemblyVersion>2.00.0</AssemblyVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13</LangVersion>
+    <AssemblyVersion>2.21.0</AssemblyVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 

--- a/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
+++ b/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
@@ -17,7 +17,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-3.final" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.final" PrivateAssets="all" />
         <PackageReference Include="System.Reflection.Metadata" Version="9.0.0" PrivateAssets="all" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" PrivateAssets="all" />
     </ItemGroup>

--- a/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
+++ b/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
@@ -15,10 +15,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" PrivateAssets="all" />
-        <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-3.final" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.final" PrivateAssets="all" />
+        <PackageReference Include="System.Reflection.Metadata" Version="9.0.0" PrivateAssets="all" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Cecilifier.Web/Cecilifier.Web.csproj
+++ b/Cecilifier.Web/Cecilifier.Web.csproj
@@ -3,6 +3,7 @@
   
   <PropertyGroup>
     <_DotNetPackTypeMapGeneratorCommand>dotnet pack $(MSBuildProjectDirectory)/../Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj</_DotNetPackTypeMapGeneratorCommand>  
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   
   <Target Name="PackCodeGeneratorPublish" AfterTargets="Publish">

--- a/Cecilifier.Web/Pages/Index.cshtml
+++ b/Cecilifier.Web/Pages/Index.cshtml
@@ -1,5 +1,6 @@
 @page
 @using Cecilifier.Core
+@using Cecilifier.Core.Misc
 @model CecilifierApplication
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
@@ -67,13 +68,13 @@
       </tr>
       <tr style="height: 40px">
           <td colspan="2">
-              <div align="center" style="vertical-align: middle; margin-bottom: 30px;">
+              <div style="margin-bottom: 35px; display: flex; justify-content: center; align-items: center; gap:5px">
                   <button type="submit" id="sendbutton" class="button">Cecilify your code!</button>
                   <button type="submit" id="downloadProject" class="button">Generate Project <i class="fa fa-box"></i></button>
                   <button class="button" id="copyToClipboard" onclick="copyToClipboard('copyPastHelper');"><i class="fa fa-copy"></i></button>
-                  <button class="button" onclick="changeCecilifierSettings();" id="changeSettings"><i class="fas fa-sliders-h"></i></button>
+                  <button class="button" id="changeSettings" onclick="changeCecilifierSettings();"><i class="fas fa-sliders-h"></i></button>
                   <button class="button" id="showFixedBugsInStaging" onclick="showListOfFixedIssuesInStagingServer(true);"><i class="fa fa-bug fa-lg"></i></button>
-                  <button class="button" onclick="ShowAssemblyReferencesDialog('Assembly References', 'ssss');" id="assembly_references_button"><i class="fas fa-database"></i></button>
+                  <button class="button" id="assembly_references_button" onclick="ShowAssemblyReferencesDialog('Assembly References', 'ssss');"><i class="fas fa-database"></i></button>
 
                   <span id="keyboard-shortcuts">
                       <i class="fas fa-keyboard" style="font-size:28px; vertical-align: middle;"></i>
@@ -161,7 +162,7 @@
 </script>
 
 <script>
-    initializeSite("@Model.ErrorAccessingGist", "@fromGist", "@Request.Path", "@Request.Query["remove"]", "@Request.Query[Constants.FrontEnd.PathNotFoundRedirectQueryParameter]", "@GetType().Assembly.GetName().Version (@System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)");
+    initializeSite("@Model.ErrorAccessingGist", "@fromGist", "@Request.Path", "@Request.Query["remove"]", "@Request.Query[Constants.FrontEnd.PathNotFoundRedirectQueryParameter]", "@GetType().Assembly.GetName().Version", "@System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription", "@BuildInformation.BuildDate()", "@BuildInformation.GitRevision()");
 </script>
 
 <script>

--- a/Cecilifier.Web/Startup.cs
+++ b/Cecilifier.Web/Startup.cs
@@ -34,10 +34,10 @@ namespace Cecilifier.Web
                                                <Project Sdk="Microsoft.NET.Sdk">
                                                    <PropertyGroup>
                                                        <OutputType>Exe</OutputType>
-                                                       <TargetFramework>net8.0</TargetFramework>
+                                                       <TargetFramework>net9.0</TargetFramework>
                                                    </PropertyGroup>
                                                    <ItemGroup>
-                                                       <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+                                                       <PackageReference Include="Mono.Cecil" Version="0.11.6" />
                                                        <PackageReference Include="Cecilifier.TypeMapGenerator" Version="1.0.0" />
                                                    </ItemGroup>
                                                </Project>

--- a/Cecilifier.Web/wwwroot/js/cecilifier.js
+++ b/Cecilifier.Web/wwwroot/js/cecilifier.js
@@ -51,7 +51,10 @@ function initializeSite(
     requestPath, // something like `/name` where `name` is the string used to store the snippet in the browser local store.
     removeStoredSnippet, // user has requested to remove the contents of a snippet from the browser local store
     pageNotFoundPath, // if user navigated to a non-existing page in cecilifier this will contain the path of the page.
-    version) {
+    cecilifierVersion,
+    frameWorkVersion,
+    buildDate,
+    buildGitRevision) {
     
     if (pageNotFoundPath != null && pageNotFoundPath.length > 0) {
         SnackBar({
@@ -120,7 +123,7 @@ class Foo
 
     showListOfFixedIssuesInStagingServer(false);
     
-    setTooltips(version);
+    setTooltips(cecilifierVersion, frameWorkVersion, buildDate, buildGitRevision);
     initializeWebSocket();
     disableScroll();
 }
@@ -384,8 +387,11 @@ function updateEditorsSize() {
     cecilifiedCode.layout();
 }
 
-function setTooltips(version) {
-    let msg = `Cecilifier version ${version}<br/><br/>Cecilifier is meant to make it easier to learn how to use <a href="https://github.com/jbevain/cecil" target="_blank">Mono.Cecil</a>. You can read more details about it in its <a href="https://programing-fun.blogspot.com/2019/02/making-it-easier-to-getting-started.html" target="_blank">blog announcement</a>.`;
+function setTooltips(cecilifierVersion,
+                     frameWorkVersion,
+                     buildDate,
+                     buildGitRevision) {
+    let msg = `Cecilifier is meant to make it easier to learn how to use <a href="https://github.com/jbevain/cecil" target="_blank">Mono.Cecil</a>.<br/>You can read more details about it in its <a href="https://programing-fun.blogspot.com/2019/02/making-it-easier-to-getting-started.html" target="_blank">blog announcement</a>.<br/><br/>Version ${cecilifierVersion} (${frameWorkVersion})<br/>Git Commig: <a href="https://github.com/adrianoc/cecilifier/commit/${buildGitRevision}">${buildGitRevision}</a></br>Built on: ${buildDate}`;
     
     let defaultDelay =  [500, null];
     tippy('#aboutSpan2', {
@@ -394,7 +400,8 @@ function setTooltips(version) {
         interactive: true,
         allowHTML: true,
         theme: 'cecilifier-tooltip',
-        delay: defaultDelay
+        delay: defaultDelay,
+        maxWidth: 'none'
     });
 
     tippy('#csharpcode-container', {


### PR DESCRIPTION
727c8818 warn about 'allow ref structs' and fix 'partial property' features (#318)
122b4062 enable nullable in ExpressionVisitor
d09e172e enabling nullable annotations and fixing reported issues in StatementVisitor.cs
4d57fb5d updates couple of .csproj to target .NET 9.0
a3c27456 getting rid of warnings and enable TreatWarningsAsErrors
525f61f8 configures both csprojs and the cecilifier itself to build with C# 13
b9fa182a update to .NET 9.0
64434d5e display build information in cecilifier's help
e9cbd370 bump version to 2.21.0
