### PR TITLE
July 2025 Update - V2.22

### DIFF
--- a/.github/workflows/cecilifier-ci.yml
+++ b/.github/workflows/cecilifier-ci.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 run-name: Verifying ${{ github.ref }} 🚀
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
  RunTests:
     runs-on: ubuntu-latest

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>13</LangVersion>
-    <AssemblyVersion>2.21.0</AssemblyVersion>
+    <AssemblyVersion>2.22.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/Cecilifier.Core.Tests/Tests/OutputBased/CollectionExpressionTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/CollectionExpressionTests.cs
@@ -56,7 +56,7 @@ public class CollectionExpressionTests : OutputBasedTestBase
     }
 
     [Test]
-    public void X()
+    public void ReferenceTypes()
     {
         AssertOutput(
             """

--- a/Cecilifier.Core.Tests/Tests/OutputBased/MemberAccessTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/MemberAccessTests.cs
@@ -1,0 +1,37 @@
+using Cecilifier.Core.Tests.Framework;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.OutputBased;
+
+[TestFixture]
+public class MemberAccessTests : OutputBasedTestBase
+{
+    [Test]
+    public void GenericRefMemberReferences_Issue340()
+    {
+        AssertOutput("""
+                    using System;
+                    using System.Runtime.CompilerServices;
+                    
+                    var n = 10;
+                    var f = new Ref<int>();
+                    f.SetItem(ref n);
+                    f.Print();
+                    n = 31;
+                    f.Print();
+                    
+                    ref struct Ref<T>
+                    {
+                        private ref T item;
+                    
+                        unsafe public void SetItem(ref T v)
+                        {
+                            item = ref Unsafe.AsRef<T>(ref v);
+                        }
+                    
+                        public void Print() => System.Console.Write(item);
+                    }
+                    """, "1031");
+        
+    }    
+}

--- a/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Cecilifier.Core.Tests.Framework;
 using NUnit.Framework;
 
@@ -6,14 +7,23 @@ namespace Cecilifier.Core.Tests.OutputBased;
 [TestFixture]
 public class ParamsTests : OutputBasedTestBase
 {
-    [TestCase("1, 2, 3", TestName = "Expanded")]
-    [TestCase("new[] { 1, 2, 3 }", TestName = "Non-Expanded")]
-    public void Test(string args)
+    [TestCaseSource(nameof(ParamsTestScenarios))]
+    public void Test(string paramsType, string args)
     {
         AssertOutput($$"""
                        using System;
                        M({{args}});
-                       void M(params int[] items) { foreach(var item in items) Console.Write($"{item},"); }
-                       """, "1,2,3,");
+                       void M(params {{paramsType}} items) { foreach(var item in items) Console.Write($"{item},"); }
+                       """, "1,2,3,", "ReturnPtrToStack");
+    }
+
+    private static IEnumerable<TestCaseData> ParamsTestScenarios()
+    {
+        string[] paramsTypes = ["int[]", "Span<int>"/*, "ReadOnlySpan<int>"*/];
+        foreach (var paramsType in paramsTypes)
+        {
+            yield return new TestCaseData(paramsType, "1, 2, 3").SetName($"Expanded - {paramsType}");
+            yield return new TestCaseData(paramsType, "new[] { 1, 2, 3 }").SetName($"Non-Expanded - {paramsType}");
+        }
     }
 }

--- a/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
@@ -19,7 +19,7 @@ public class ParamsTests : OutputBasedTestBase
 
     private static IEnumerable<TestCaseData> ParamsTestScenarios()
     {
-        string[] paramsTypes = ["int[]", "Span<int>"/*, "ReadOnlySpan<int>"*/];
+        string[] paramsTypes = ["int[]", "Span<int>", "ReadOnlySpan<int>"];
         foreach (var paramsType in paramsTypes)
         {
             yield return new TestCaseData(paramsType, "1, 2, 3").SetName($"Expanded - {paramsType}");
@@ -27,3 +27,4 @@ public class ParamsTests : OutputBasedTestBase
         }
     }
 }
+

--- a/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
@@ -1,0 +1,19 @@
+using Cecilifier.Core.Tests.Framework;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.OutputBased;
+
+[TestFixture]
+public class ParamsTests : OutputBasedTestBase
+{
+    [TestCase("1, 2, 3", TestName = "Expanded")]
+    [TestCase("new[] { 1, 2, 3 }", TestName = "Non-Expanded")]
+    public void Test(string args)
+    {
+        AssertOutput($$"""
+                       using System;
+                       M({{args}});
+                       void M(params int[] items) { foreach(var item in items) Console.Write($"{item},"); }
+                       """, "1,2,3,");
+    }
+}

--- a/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/OutputBased/ParamsTests.cs
@@ -8,18 +8,19 @@ namespace Cecilifier.Core.Tests.OutputBased;
 public class ParamsTests : OutputBasedTestBase
 {
     [TestCaseSource(nameof(ParamsTestScenarios))]
-    public void Test(string paramsType, string args)
+    public void TestNonNullables(string paramsType, string args)
     {
         AssertOutput($$"""
                        using System;
+                       using System.Collections.Generic;
                        M({{args}});
                        void M(params {{paramsType}} items) { foreach(var item in items) Console.Write($"{item},"); }
                        """, "1,2,3,", "ReturnPtrToStack");
     }
-
+    
     private static IEnumerable<TestCaseData> ParamsTestScenarios()
     {
-        string[] paramsTypes = ["int[]", "Span<int>", "ReadOnlySpan<int>"];
+        string[] paramsTypes = ["int[]", "Span<int>", "ReadOnlySpan<int>", "IList<int>", "ICollection<int>"];
         foreach (var paramsType in paramsTypes)
         {
             yield return new TestCaseData(paramsType, "1, 2, 3").SetName($"Expanded - {paramsType}");

--- a/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/MemberAccessTests.cs
@@ -205,14 +205,14 @@ class Foo
         Assert.That(cecilifiedCode, Does.Match(expectedExpressions));
     }
 
-    [TestCase("where T : struct", "string ConstrainedToStruct() => field.ToString();", "Ldflda, fld_field_4", "Constrained, gp_T_3")]
-    [TestCase("where T : IFoo", "string ConstrainedToInterfaceCallInterfaceMethod() => field.Get();", "Ldflda, fld_field_4", "Constrained, gp_T_3")]
-    [TestCase("where T : IFoo", "string ConstrainedToInterfaceCallToString() => field.ToString();", "Ldflda, fld_field_4", "Constrained, gp_T_3")]
-    [TestCase("", "string Unconstrained() => field.ToString();", "Ldflda, fld_field_4", "Constrained, gp_T_3")]
-    [TestCase("where T : class", "string ConstrainedToReferenceType() => field.ToString();", "Ldfld, fld_field_4", "Box, gp_T_3")]
-    [TestCase("where T: Bar", "string ConstrainedToClassCallToString() => field.ToString();", "Ldfld, fld_field_9", "Box, gp_T_8")]
-    [TestCase("where T: Bar", "void ConstrainedToClassCallClassMethod() => field.M();", "Ldfld, fld_field_9", "Box, gp_T_8")]
-    public void TestCallOn_TypeParameter_CallOnField(string constraint, string snippet, params string[] expectedExpressions)
+    [TestCase("where T : struct", "string ConstrainedToStruct() => field.ToString();", "Ldflda", "Constrained, gp_T_3")]
+    [TestCase("where T : IFoo", "string ConstrainedToInterfaceCallInterfaceMethod() => field.Get();", "Ldflda", "Constrained, gp_T_3")]
+    [TestCase("where T : IFoo", "string ConstrainedToInterfaceCallToString() => field.ToString();", "Ldflda", "Constrained, gp_T_3")]
+    [TestCase("", "string Unconstrained() => field.ToString();", "Ldflda", "Constrained, gp_T_3")]
+    [TestCase("where T : class", "string ConstrainedToReferenceType() => field.ToString();", """Ldfld""", "Box, gp_T_3")]
+    [TestCase("where T: Bar", "string ConstrainedToClassCallToString() => field.ToString();", "Ldfld", "Box, gp_T_8")]
+    [TestCase("where T: Bar", "void ConstrainedToClassCallClassMethod() => field.M();", "Ldfld", "Box, gp_T_8")]
+    public void TestCallOn_TypeParameter_CallOnField(string constraint, string snippet, string expectedLoadOpCode, string expectedConversionExpression)
     {
         var code = $@"interface IFoo {{ string Get(); }}
 class Foo<T> {constraint}
@@ -225,8 +225,8 @@ class Bar {{ public void M() {{ }} }}
 ";
         var result = RunCecilifier(code);
         var cecilifiedCode = result.GeneratedCode.ReadToEnd();
-        foreach (var expectedExpression in expectedExpressions)
-            Assert.That(cecilifiedCode, Contains.Substring(expectedExpression));
+        Assert.That(cecilifiedCode, Does.Match($"""{expectedLoadOpCode}, new FieldReference\("field", gp_T_\d+, cls_foo_\d+.MakeGenericInstanceType\(gp_T_\d+\)\)"""));
+        Assert.That(cecilifiedCode, Does.Match(expectedLoadOpCode));
     }
 
     // Issue #187
@@ -289,5 +289,49 @@ class Bar {{ public void M() {{ }} }}
             pattern = pattern.Replace("\n\n", "\n");
         
         Assert.That(cecilifiedCode, Does.Match(pattern));
+    }
+
+    [Test]
+    public void GenericMemberReferences_Issue334()
+    {
+        var result = RunCecilifier("""
+                                   using System; 
+                                   class C<T> 
+                                   { 
+                                        T field; 
+                                        event Action Event; 
+                                        T Property {get; set; } 
+                                        
+                                        public void Set(T toSet) => field = toSet; 
+                                        // Issue #339
+                                        // public void SetEvent(Action toSet) => Event += toSet; 
+                                        public void SetProperty(T toSet) => Property = toSet;
+                                   }
+                                   """);
+        var actual = result.GeneratedCode.ReadToEnd();
+        Assert.That(actual, Does.Match("""
+                                          //field = toSet
+                                          (?<emit>\s+il_set_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                                          \k<emit>Ldarg_1\);
+                                          \k<emit>Stfld, new FieldReference\("field", (?<typeParam>gp_T_\d+), cls_C_\d+.MakeGenericInstanceType\(\k<typeParam>\)\)\);
+                                          """));
+        
+        Assert.That(actual, Does.Match("""
+                                          //Property = toSet
+                                          (?<emit>\s+il_setProperty_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                                          \k<emit>Ldarg_1\);
+                                          \s+var (?<setter>r_set_Property_\d+) = new MethodReference\(l_set_\d+.Name, l_set_\d+.ReturnType\) {.+DeclaringType = cls_C_\d+.MakeGenericInstanceType\(gp_T_\d+\).+};
+                                          \s+foreach\(var p in l_set_\d+.Parameters\)
+                                          \s+{
+                                          \s+\k<setter>\.Parameters.Add\(new ParameterDefinition\(p.Name, p.Attributes, p.ParameterType\)\);
+                                          \s+}
+                                          \k<emit>Call, \k<setter>\);
+                                          """));
+        
+        // Placeholder for events. Ignore(#339)
+        // Assert.That(actual, Does.Match("""
+        //                                   //Event += toSet
+        //                                   ....
+        //                                   """));
     }
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Cecilifier.Core.Tests.Tests.Unit.Framework;
@@ -6,7 +7,7 @@ using NUnit.Framework;
 namespace Cecilifier.Core.Tests.Tests.Unit;
 
 [TestFixture]
-public class ParamsArraysTests : CecilifierUnitTestBase
+public class ParamsTests : CecilifierUnitTestBase
 {
     [TestCaseSource(nameof(CallSiteTestScenarios))]
     public void CallSite(string paramsType, string expectedRegex)
@@ -22,32 +23,7 @@ public class ParamsArraysTests : CecilifierUnitTestBase
                                    }
                                    """);
         
-        Assert.That(
-            result.GeneratedCode.ReadToEnd(), 
-            Does.Match("""
-                       //M\(1, 2, 3\)
-                       (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
-                       \s+var (?<itemsParams>l_itemsParams_\d+) = new VariableDefinition\(.+Int32\.MakeArrayType\(\)\);
-                       \s+m_use_\d+.Body.Variables.Add\(\k<itemsParams>\);
-                       \k<emit>Ldc_I4, 3\);
-                       \k<emit>Newarr, .+Int32\);
-                       \k<emit>Stloc, \k<itemsParams>\);
-                       \k<emit>Ldloc, \k<itemsParams>\);
-                       \k<emit>Dup\);
-                       \k<emit>Ldc_I4, 0\);
-                       \k<emit>Ldc_I4, 1\);
-                       \k<emit>Stelem_I4\);
-                       \k<emit>Dup\);
-                       \k<emit>Ldc_I4, 1\);
-                       \k<emit>Ldc_I4, 2\);
-                       \k<emit>Stelem_I4\);
-                       \k<emit>Dup\);
-                       \k<emit>Ldc_I4, 2\);
-                       \k<emit>Ldc_I4, 3\);
-                       \k<emit>Stelem_I4\);
-                       \k<emit>Call, m_M_\d+\);
-                       \k<emit>Ret\);
-                       """));
+        Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(expectedRegex));
     }
     
     static IEnumerable<TestCaseData> CallSiteTestScenarios()
@@ -57,29 +33,18 @@ public class ParamsArraysTests : CecilifierUnitTestBase
             """
             //M\(1, 2, 3\)
             (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+            \s+var (?<paramsVar>l_itemsParams_\d+) = new VariableDefinition\(.+Int32.MakeArrayType\(\)\);
+            \s+m_use_\d+.Body.Variables.Add\(\k<paramsVar>\);
             \k<emit>Ldc_I4, 3\);
-            \k<emit>NewArray, .+Int32.+\);
-            \k<emit>Dup\);
-            \k<emit>Ldc_I4, 0\);
-            \k<emit>Ldc_I4, 1\);
-            \k<emit>StElem_I4\);
-            \k<emit>Dup\);
-            \k<emit>Ldc_I4, 1\);
-            \k<emit>Ldc_I4, 2\);
-            \k<emit>StElem_I4\);
-            \k<emit>Dup\);
-            \k<emit>Ldc_I4, 2\);
-            \k<emit>Ldc_I4, 3\);
-            \k<emit>StElem_I4\);
-            \k<emit>Call, m_M_\d+\);
-            \k<emit>Ret\);
             """).SetName("int[]");
         
         yield return new TestCaseData(
             "Span<int>",
             """
-            
-            """).SetName("Span<int>").Ignore("placeholder");
+            //M\(1, 2, 3\)
+            (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+            \s+//InlineArray to store the `params` values.
+            """).SetName("Span<int>");
         
         yield return new TestCaseData(
             "ReadOnlySpan<int>",
@@ -106,14 +71,15 @@ public class ParamsArraysTests : CecilifierUnitTestBase
             """).SetName("IEnumerable<int>").Ignore("placeholder");
     }
 
-    [TestCase("int[]", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
-    [TestCase("Span<int>", @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("ReadOnlySpan<int>", @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("IList<int>", @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("ICollection<int>", @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("IEnumerable<int>", @".+ImportReference\(typeof\(.+IEnumerable<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    public void Declaration(string paramsType, string actualCecilParameterType)
+    [TestCase("int[]", "ParamArrayAttribute", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
+    [TestCase("Span<int>", null, @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("ReadOnlySpan<int>", null, @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
+    [TestCase("IList<int>", null, @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
+    [TestCase("ICollection<int>", null, @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
+    [TestCase("IEnumerable<int>", null, @".+ImportReference\(typeof\(.+IEnumerable<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
+    public void Declaration(string paramsType, string? paramsAttribute, string actualCecilParameterType)
     {
+            paramsAttribute ??= "ParamCollectionAttribute";
         var result = RunCecilifier($$"""
                                      using System.Collections.Generic;
                                      using System;
@@ -129,12 +95,11 @@ public class ParamsArraysTests : CecilifierUnitTestBase
                          //M\(1, 2, 3\);
                          \s+var (?<mv>m_M_\d+) = new MethodDefinition\(".+g__M\|0_0", MethodAttributes.Private, assembly.MainModule.TypeSystem.Void\);
                          \s+var (?<pp>p_items_\d+) = new ParameterDefinition\("items", ParameterAttributes.None,{actualCecilParameterType}.?\);
-                         \s+\k<pp>\.CustomAttributes\.Add\(new CustomAttribute\(.+ParamArrayAttribute\)\.GetConstructor\(.+\)\)\)\);
+                         \s+\k<pp>\.CustomAttributes\.Add\(new CustomAttribute\(.+{paramsAttribute}\)\.GetConstructor\(.+\)\)\)\);
                          \s+\k<mv>\.Parameters\.Add\(\k<pp>\);
                          """));
     }
 }
-
 
 static class Extensions
 {

--- a/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
@@ -7,6 +8,104 @@ namespace Cecilifier.Core.Tests.Tests.Unit;
 [TestFixture]
 public class ParamsArraysTests : CecilifierUnitTestBase
 {
+    [TestCaseSource(nameof(CallSiteTestScenarios))]
+    public void CallSite(string paramsType, string expectedRegex)
+    {
+        var result = RunCecilifier($$"""
+                                   using System.Collections.Generic;
+                                   using System;
+                                   
+                                   class Foo 
+                                   {
+                                        void Use() => M(1, 2, 3);
+                                        void M(params {{paramsType}} items) { }
+                                   }
+                                   """);
+        
+        Assert.That(
+            result.GeneratedCode.ReadToEnd(), 
+            Does.Match("""
+                       //M\(1, 2, 3\)
+                       (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                       \s+var (?<itemsParams>l_itemsParams_\d+) = new VariableDefinition\(.+Int32\.MakeArrayType\(\)\);
+                       \s+m_use_\d+.Body.Variables.Add\(\k<itemsParams>\);
+                       \k<emit>Ldc_I4, 3\);
+                       \k<emit>Newarr, .+Int32\);
+                       \k<emit>Stloc, \k<itemsParams>\);
+                       \k<emit>Ldloc, \k<itemsParams>\);
+                       \k<emit>Dup\);
+                       \k<emit>Ldc_I4, 0\);
+                       \k<emit>Ldc_I4, 1\);
+                       \k<emit>Stelem_I4\);
+                       \k<emit>Dup\);
+                       \k<emit>Ldc_I4, 1\);
+                       \k<emit>Ldc_I4, 2\);
+                       \k<emit>Stelem_I4\);
+                       \k<emit>Dup\);
+                       \k<emit>Ldc_I4, 2\);
+                       \k<emit>Ldc_I4, 3\);
+                       \k<emit>Stelem_I4\);
+                       \k<emit>Call, m_M_\d+\);
+                       \k<emit>Ret\);
+                       """));
+    }
+    
+    static IEnumerable<TestCaseData> CallSiteTestScenarios()
+    {
+        yield return new TestCaseData(
+            "int[]",
+            """
+            //M\(1, 2, 3\)
+            (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+            \k<emit>Ldc_I4, 3\);
+            \k<emit>NewArray, .+Int32.+\);
+            \k<emit>Dup\);
+            \k<emit>Ldc_I4, 0\);
+            \k<emit>Ldc_I4, 1\);
+            \k<emit>StElem_I4\);
+            \k<emit>Dup\);
+            \k<emit>Ldc_I4, 1\);
+            \k<emit>Ldc_I4, 2\);
+            \k<emit>StElem_I4\);
+            \k<emit>Dup\);
+            \k<emit>Ldc_I4, 2\);
+            \k<emit>Ldc_I4, 3\);
+            \k<emit>StElem_I4\);
+            \k<emit>Call, m_M_\d+\);
+            \k<emit>Ret\);
+            """).SetName("int[]");
+        
+        yield return new TestCaseData(
+            "Span<int>",
+            """
+            
+            """).SetName("Span<int>").Ignore("placeholder");
+        
+        yield return new TestCaseData(
+            "ReadOnlySpan<int>",
+            """
+            
+            """).SetName("ReadOnlySpan<int>").Ignore("placeholder");
+        
+        yield return new TestCaseData(
+            "IList<int>",
+            """
+            
+            """).SetName("IList<int>").Ignore("placeholder");
+        
+        yield return new TestCaseData(
+            "ICollection<int>",
+            """
+            
+            """).SetName("ICollection<int>").Ignore("placeholder");
+        
+        yield return new TestCaseData(
+            "IEnumerable<int>",
+            """
+            
+            """).SetName("IEnumerable<int>").Ignore("placeholder");
+    }
+
     [TestCase("int[]", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
     [TestCase("Span<int>", @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
     [TestCase("ReadOnlySpan<int>", @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]

--- a/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/Params.Arrays.Tests.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using Cecilifier.Core.Tests.Tests.Unit.Framework;
+using NUnit.Framework;
+
+namespace Cecilifier.Core.Tests.Tests.Unit;
+
+[TestFixture]
+public class ParamsArraysTests : CecilifierUnitTestBase
+{
+    [TestCase("int[]", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
+    [TestCase("Span<int>", @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("ReadOnlySpan<int>", @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("IList<int>", @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("ICollection<int>", @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("IEnumerable<int>", @".+ImportReference\(typeof\(.+IEnumerable<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    public void Declaration(string paramsType, string actualCecilParameterType)
+    {
+        var result = RunCecilifier($$"""
+                                     using System.Collections.Generic;
+                                     using System;
+
+                                     M(1, 2, 3);
+
+                                     void M(params {{paramsType}} items) { }
+                                     """);
+        
+        Assert.That(
+            result.GeneratedCode.ReadToEnd(), 
+            Does.Match($"""
+                         //M\(1, 2, 3\);
+                         \s+var (?<mv>m_M_\d+) = new MethodDefinition\(".+g__M\|0_0", MethodAttributes.Private, assembly.MainModule.TypeSystem.Void\);
+                         \s+var (?<pp>p_items_\d+) = new ParameterDefinition\("items", ParameterAttributes.None,{actualCecilParameterType}.?\);
+                         \s+\k<pp>\.CustomAttributes\.Add\(new CustomAttribute\(.+ParamArrayAttribute\)\.GetConstructor\(.+\)\)\)\);
+                         \s+\k<mv>\.Parameters\.Add\(\k<pp>\);
+                         """));
+    }
+}
+
+
+static class Extensions
+{
+    public static string RegexEncoded(this string str) => Regex.Replace(str, @"(\[|\])", "\\$1");
+}

--- a/Cecilifier.Core.Tests/Tests/Unit/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ParamsTests.cs
@@ -1,10 +1,8 @@
 #nullable enable
 using System.Collections.Generic;
-using System.Linq;
 using Cecilifier.Core.Misc;
 using Cecilifier.Core.Tests.Tests.Unit.Framework;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;
 
@@ -12,7 +10,7 @@ namespace Cecilifier.Core.Tests.Tests.Unit;
 public class ParamsTests : CecilifierUnitTestBase
 {
     [TestCaseSource(nameof(CallSiteTestScenarios))]
-    public void CallSite(string paramsType, params string[] expectedRegex)
+    public void SimplestCallSite(string paramsType, params string[] expectedRegex)
     {
         var result = RunCecilifier($$"""
                                    using System.Collections.Generic;
@@ -20,7 +18,7 @@ public class ParamsTests : CecilifierUnitTestBase
                                    
                                    class Foo 
                                    {
-                                        void Use() => M(1, 2, 3);
+                                        void Use(int n) => M(1, 2, n);
                                         void M(params {{paramsType}} items) { }
                                    }
                                    """);
@@ -32,13 +30,98 @@ public class ParamsTests : CecilifierUnitTestBase
         }
     }
     
+    [TestCase("long[]", """
+                        (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldc_I4, 2\);
+                        \k<emit>Ldarg_1\);
+                        \k<emit>Conv_I8\);
+                        \k<emit>Stelem_I8\);
+                        """)]
+    
+    [TestCase("Span<long>", """
+                            (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldc_I4, 2\);
+                            \k<emit>Call, gi_inlineArrayElementRef_\d+\);
+                            \k<emit>Ldarg_1\);
+                            \k<emit>Conv_I8\);
+                            \k<emit>Stind_I8\);
+                            """)]
+    
+    [TestCase("IList<long>", """
+                             (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Call, m_getItem_\d+\);
+                             \k<emit>Ldarg_1\);
+                             \k<emit>Conv_I8\);
+                             \k<emit>Stind_I8\);
+                             """)]
+    public void LongConversionAtCallSite(string paramsType, string expectedRegex)
+    {
+        var result = RunCecilifier($$"""
+                                     using System.Collections.Generic;
+                                     using System;
+
+                                     class Foo 
+                                     {
+                                          void Use(int n) => M(1, 2, n);
+                                          void M(params {{paramsType}} items) { }
+                                     }
+                                     """);
+        
+        var actual = result.GeneratedCode.ReadToEnd();
+        Assert.That(actual, Does.Match(expectedRegex));
+    }
+    
+    [TestCase("int[]", "ParamArrayAttribute", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
+    [TestCase("Span<int>", null, @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("ReadOnlySpan<int>", null, @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("IList<int>", null, @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    [TestCase("ICollection<int>", null, @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
+    public void Declaration(string paramsType, string? paramsAttribute, string actualCecilParameterType)
+    {
+        paramsAttribute ??= "ParamCollectionAttribute";
+        var result = RunCecilifier($$"""
+                                     using System.Collections.Generic;
+                                     using System;
+
+                                     M(1, 2, 3);
+
+                                     void M(params {{paramsType}} items) { }
+                                     """);
+        
+        Assert.That(
+            result.GeneratedCode.ReadToEnd(), 
+            Does.Match($"""
+                         //M\(1, 2, 3\);
+                         \s+var (?<mv>m_M_\d+) = new MethodDefinition\(".+g__M\|0_0", MethodAttributes.Private, assembly.MainModule.TypeSystem.Void\);
+                         \s+var (?<pp>p_items_\d+) = new ParameterDefinition\("items", ParameterAttributes.None,{actualCecilParameterType}.?\);
+                         \s+\k<pp>\.CustomAttributes\.Add\(new CustomAttribute\(.+{paramsAttribute}\)\.GetConstructor\(.+\)\)\)\);
+                         \s+\k<mv>\.Parameters\.Add\(\k<pp>\);
+                         """));
+    }
+
+    [TestCase("IEnumerable<int>")]
+    [TestCase("IEnumerable<T>")]
+    public void TestUnsupportedTypesAsParams(string paramsType)
+    {
+        var result = RunCecilifier($$"""
+                                   using System.Collections.Generic;
+                                   using System;
+
+                                   M(0, 1, 2, 3);
+
+                                   void M<T>(T value, params {{paramsType}} items) { }
+                                   """);
+
+        Assert.That(result.Diagnostics.Count, Is.EqualTo(1));
+        Assert.That(result.Diagnostics[0].Kind, Is.EqualTo(DiagnosticKind.Error));
+        Assert.That(result.Diagnostics[0].Message, Contains.Substring("Cecilifier does not support type System.Collections.Generic.IEnumerable<int> as a 'params' parameter (items). You may change items' to 'ICollection<T>'"));
+        Assert.That(result.GeneratedCode.ReadToEnd(), Contains.Substring(result.Diagnostics[0].Message));
+    }
+    
     static IEnumerable<TestCaseData> CallSiteTestScenarios()
     {
         yield return new TestCaseData(
             "int[]",
             new [] {
                 """
-                //M\(1, 2, 3\)
+                //M\(1, 2, n\)
                 (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
                 \s+var (?<paramsVar>l_itemsParams_\d+) = new VariableDefinition\(.+Int32.MakeArrayType\(\)\);
                 \s+m_use_\d+.Body.Variables.Add\(\k<paramsVar>\);
@@ -50,7 +133,7 @@ public class ParamsTests : CecilifierUnitTestBase
             "Span<int>",
             new [] {
                 """
-                //M\(1, 2, 3\)
+                //M\(1, 2, n\)
                 (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
                 \s+//InlineArray to store the `params` values.
                 """
@@ -61,7 +144,7 @@ public class ParamsTests : CecilifierUnitTestBase
             new [] 
             {
                 """
-                //M\(1, 2, 3\)
+                //M\(1, 2, n\)
                 (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
                 \s+//InlineArray to store the `params` values.
                 """,
@@ -87,73 +170,83 @@ public class ParamsTests : CecilifierUnitTestBase
                 \k<emit>Ldloca_S, \k<ila>\);
                 \k<emit>Ldc_I4, 2\);
                 \k<emit>Call, gi_inlineArrayElementRef_\d+\);
-                \k<emit>Ldc_I4, 3\);
+                \k<emit>Ldarg_1\);
                 \k<emit>Stind_I4\);
                 """ // Populates inline array with data to be passed to params[]
             }).SetName("ReadOnlySpan<int>");
         
-        yield return new TestCaseData(
+        var ilistTestData = new TestCaseData(
             "IList<int>",
             new []
             {
                 """
-
+                //M\(1, 2, n\)
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                \s+//Instantiates a List<T> passing the # of elements to its ctor.
+                \k<emit>Ldc_I4, 3\);
+                \k<emit>Newobj, .+ImportReference\(.+List<System.Int32>\).+\);
+                \k<emit>Dup\);
+                """,
                 """
-            }).SetName("IList<int>").Ignore("placeholder");
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldc_I4, 0\);
+                \k<emit>Call, m_getItem_\d+\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, l_listSpan_\d+\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Call, m_getItem_\d+\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, l_listSpan_\d+\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Call, m_getItem_\d+\);
+                \k<emit>Ldarg_1\);
+                \k<emit>Stind_I4\);
+                \k<emit>Call, m_M_\d+\);
+                """
+            }).SetName("IList<int>");
+
+        yield return ilistTestData;
         
         yield return new TestCaseData(
             "ICollection<int>",
-            new []
+            (string[]) ilistTestData.Arguments[1]!) // call site code generated for ICollection<T> is identical to the code generated for IList<T>.
+            .SetName("ICollection<int>");
+        
+        yield return new TestCaseData(
+            "ReadOnlySpan<int>",
+            new [] 
             {
                 """
-
+                //M\(1, 2, n\)
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                \s+//InlineArray to store the `params` values.
+                """,
+                
                 """
-            }).SetName("ICollection<int>").Ignore("placeholder");
-    }
-
-    [TestCase("int[]", "ParamArrayAttribute", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
-    [TestCase("Span<int>", null, @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("ReadOnlySpan<int>", null, @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("IList<int>", null, @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
-    [TestCase("ICollection<int>", null, @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
-    public void Declaration(string paramsType, string? paramsAttribute, string actualCecilParameterType)
-    {
-        paramsAttribute ??= "ParamCollectionAttribute";
-        var result = RunCecilifier($$"""
-                                     using System.Collections.Generic;
-                                     using System;
-
-                                     M(1, 2, 3);
-
-                                     void M(params {{paramsType}} items) { }
-                                     """);
-        
-        Assert.That(
-            result.GeneratedCode.ReadToEnd(), 
-            Does.Match($"""
-                         //M\(1, 2, 3\);
-                         \s+var (?<mv>m_M_\d+) = new MethodDefinition\(".+g__M\|0_0", MethodAttributes.Private, assembly.MainModule.TypeSystem.Void\);
-                         \s+var (?<pp>p_items_\d+) = new ParameterDefinition\("items", ParameterAttributes.None,{actualCecilParameterType}.?\);
-                         \s+\k<pp>\.CustomAttributes\.Add\(new CustomAttribute\(.+{paramsAttribute}\)\.GetConstructor\(.+\)\)\)\);
-                         \s+\k<mv>\.Parameters\.Add\(\k<pp>\);
-                         """));
-    }
-
-    [Test]
-    public void TestUnsupportedTypesAsParams()
-    {
-        var result = RunCecilifier("""
-                                   using System.Collections.Generic;
-                                   using System;
-
-                                   M(1, 2, 3);
-
-                                   void M(params IEnumerable<int> items) { }
-                                   """);
-
-        Assert.That(result.Diagnostics.Count, Is.EqualTo(1));
-        Assert.That(result.Diagnostics[0].Kind, Is.EqualTo(DiagnosticKind.Error));
-        Assert.That(result.Diagnostics[0].Message, Contains.Substring("Cecilifier does not support type System.Collections.Generic.IEnumerable<int> as a 'params' parameter (items). You may change items' to 'ICollection<T>'"));
-        Assert.That(result.GeneratedCode.ReadToEnd(), Contains.Substring(result.Diagnostics[0].Message));
+                var (?<ila>l_itemsArg_\d+) = new VariableDefinition\(st_inlineArray_\d+.MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);
+                \s+m_use_\d+.Body.Variables.Add\(\k<ila>\);
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldloca_S, \k<ila>\);
+                \k<emit>Initobj, st_inlineArray_\d+.MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);
+                \k<emit>Ldloca_S, \k<ila>\);
+                \k<emit>Ldc_I4, 0\);
+                """, // Declares and initialize a variable of an inline array type used to store the data.
+                
+                """
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, (?<ila>l_itemsArg_\d+)\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, \k<ila>\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldarg_1\);
+                \k<emit>Stind_I4\);
+                """ // Populates inline array with data to be passed to params[]
+            }).SetName("ReadOnlySpan<int>");
     }
 }

--- a/Cecilifier.Core.Tests/Tests/Unit/ParamsTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/ParamsTests.cs
@@ -10,7 +10,7 @@ namespace Cecilifier.Core.Tests.Tests.Unit;
 public class ParamsTests : CecilifierUnitTestBase
 {
     [TestCaseSource(nameof(CallSiteTestScenarios))]
-    public void CallSite(string paramsType, string expectedRegex)
+    public void CallSite(string paramsType, params string[] expectedRegex)
     {
         var result = RunCecilifier($$"""
                                    using System.Collections.Generic;
@@ -23,63 +23,110 @@ public class ParamsTests : CecilifierUnitTestBase
                                    }
                                    """);
         
-        Assert.That(result.GeneratedCode.ReadToEnd(), Does.Match(expectedRegex));
+        var actual = result.GeneratedCode.ReadToEnd();
+        foreach (var regex in expectedRegex)
+        {
+            Assert.That(actual, Does.Match(regex));
+        }
     }
     
     static IEnumerable<TestCaseData> CallSiteTestScenarios()
     {
         yield return new TestCaseData(
             "int[]",
-            """
-            //M\(1, 2, 3\)
-            (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
-            \s+var (?<paramsVar>l_itemsParams_\d+) = new VariableDefinition\(.+Int32.MakeArrayType\(\)\);
-            \s+m_use_\d+.Body.Variables.Add\(\k<paramsVar>\);
-            \k<emit>Ldc_I4, 3\);
-            """).SetName("int[]");
+            new [] {
+                """
+                //M\(1, 2, 3\)
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                \s+var (?<paramsVar>l_itemsParams_\d+) = new VariableDefinition\(.+Int32.MakeArrayType\(\)\);
+                \s+m_use_\d+.Body.Variables.Add\(\k<paramsVar>\);
+                \k<emit>Ldc_I4, 3\);
+                """
+            }).SetName("int[]");
         
         yield return new TestCaseData(
             "Span<int>",
-            """
-            //M\(1, 2, 3\)
-            (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
-            \s+//InlineArray to store the `params` values.
-            """).SetName("Span<int>");
+            new [] {
+                """
+                //M\(1, 2, 3\)
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                \s+//InlineArray to store the `params` values.
+                """
+            }).SetName("Span<int>");
         
         yield return new TestCaseData(
             "ReadOnlySpan<int>",
-            """
-            
-            """).SetName("ReadOnlySpan<int>").Ignore("placeholder");
+            new [] 
+            {
+                """
+                //M\(1, 2, 3\)
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldarg_0\);
+                \s+//InlineArray to store the `params` values.
+                """,
+                
+                """
+                var (?<ila>l_itemsArg_\d+) = new VariableDefinition\(st_inlineArray_\d+.MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);
+                \s+m_use_\d+.Body.Variables.Add\(\k<ila>\);
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Ldloca_S, \k<ila>\);
+                \k<emit>Initobj, st_inlineArray_\d+.MakeGenericInstanceType\(assembly.MainModule.TypeSystem.Int32\)\);
+                \k<emit>Ldloca_S, \k<ila>\);
+                \k<emit>Ldc_I4, 0\);
+                """, // Declares and initialize a variable of an inline array type used to store the data.
+                
+                """
+                (?<emit>\s+il_use_\d+\.Emit\(OpCodes\.)Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, (?<ila>l_itemsArg_\d+)\);
+                \k<emit>Ldc_I4, 1\);
+                \k<emit>Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Stind_I4\);
+                \k<emit>Ldloca_S, \k<ila>\);
+                \k<emit>Ldc_I4, 2\);
+                \k<emit>Call, gi_inlineArrayElementRef_\d+\);
+                \k<emit>Ldc_I4, 3\);
+                \k<emit>Stind_I4\);
+                """ // Populates inline array with data to be passed to params[]
+            }).SetName("ReadOnlySpan<int>");
         
         yield return new TestCaseData(
             "IList<int>",
-            """
-            
-            """).SetName("IList<int>").Ignore("placeholder");
+            new [] 
+            {
+                """
+
+                """
+            }).SetName("IList<int>").Ignore("placeholder");
         
         yield return new TestCaseData(
             "ICollection<int>",
-            """
-            
-            """).SetName("ICollection<int>").Ignore("placeholder");
+            new [] 
+            {
+                """
+
+                """
+            }).SetName("ICollection<int>").Ignore("placeholder");
         
         yield return new TestCaseData(
             "IEnumerable<int>",
-            """
-            
-            """).SetName("IEnumerable<int>").Ignore("placeholder");
+            new [] 
+            {
+                """
+
+                """
+            }).SetName("IEnumerable<int>").Ignore("placeholder");
     }
 
     [TestCase("int[]", "ParamArrayAttribute", @".+assembly\.MainModule\.TypeSystem\.Int32\.MakeArrayType\(\)")]
     [TestCase("Span<int>", null, @".+ImportReference\(typeof\(.+Span<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
-    [TestCase("ReadOnlySpan<int>", null, @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
+    [TestCase("ReadOnlySpan<int>", null, @".+ImportReference\(typeof\(.+ReadOnlySpan<>\)\)\.MakeGenericInstanceType\(.+Int32\)")]
     [TestCase("IList<int>", null, @".+ImportReference\(typeof\(.+IList<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
     [TestCase("ICollection<int>", null, @".+ImportReference\(typeof\(.+ICollection<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
     [TestCase("IEnumerable<int>", null, @".+ImportReference\(typeof\(.+IEnumerable<>\)\)\.MakeGenericInstanceType\(.+Int32\)", IgnoreReason = "Placeholder")]
     public void Declaration(string paramsType, string? paramsAttribute, string actualCecilParameterType)
     {
-            paramsAttribute ??= "ParamCollectionAttribute";
+        paramsAttribute ??= "ParamCollectionAttribute";
         var result = RunCecilifier($$"""
                                      using System.Collections.Generic;
                                      using System;

--- a/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
@@ -466,7 +466,7 @@ public class StructSpecificTests : CecilifierUnitTestBase
         """
             //field.M\(42\)
             \s+il_call_\d+.Emit\(OpCodes\.Ldarg_0\);
-            \s+il_call_\d+.Emit\(OpCodes\.Ldflda, fld_field_\d+\);
+            \s+il_call_\d+.Emit\(OpCodes\.Ldflda, new FieldReference\("field", gp_T_\d+, cls_field_\d+.MakeGenericInstanceType\(gp_T_\d+\)\)\);
             """,
         TestName = "On Field")]
     public void CallOnValueType_ThroughInterface_IsConstrained(string t, string loadTargetOfCallIlRegex)

--- a/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/StructSpecificTests.cs
@@ -466,7 +466,7 @@ public class StructSpecificTests : CecilifierUnitTestBase
         """
             //field.M\(42\)
             \s+il_call_\d+.Emit\(OpCodes\.Ldarg_0\);
-            \s+il_call_\d+.Emit\(OpCodes\.Ldflda, new FieldReference\("field", gp_T_\d+, cls_field_\d+.MakeGenericInstanceType\(gp_T_\d+\)\)\);
+            \s+il_call_\d+.Emit\(OpCodes\.Ldflda, new FieldReference\(fld_field_\d+.Name, fld_field_\d+.FieldType, cls_field_\d+.MakeGenericInstanceType\(gp_T_\d+\)\)\);
             """,
         TestName = "On Field")]
     public void CallOnValueType_ThroughInterface_IsConstrained(string t, string loadTargetOfCallIlRegex)

--- a/Cecilifier.Core.Tests/Tests/Unit/TypeHelpersTests.cs
+++ b/Cecilifier.Core.Tests/Tests/Unit/TypeHelpersTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using Cecilifier.Runtime;
+using Mono.Cecil;
 using NUnit.Framework;
 
 namespace Cecilifier.Core.Tests.Tests.Unit;
@@ -19,6 +20,14 @@ public class TypeHelpersTests
     public void ResolveField_Throws_IfTypeCannotBeFound()
     {
         Assert.Throws<Exception>(() => TypeHelpers.ResolveField("NonExistingType", "NotRelevant_TypeDoesNotExist"));
+    }
+
+    [Test]
+    public void TryMapAssemblyFromType_ResolveInnerTypes()
+    {
+        var fixer = new PrivateCorlibFixerMixin(ModuleDefinition.CreateModule("Test", ModuleKind.Dll));
+        var result = fixer.TryMapAssemblyFromType("System.Collections.Generic.List`1+Enumerator", out _);
+        Assert.That(result, Is.True);
     }
 
     public class Foo

--- a/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
+++ b/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
@@ -52,7 +52,6 @@ internal static class CollectionExpressionProcessor
             context.EmitCilInstruction(visitor.ILVariable, OpCodes.Ldc_I4, index);
             context.EmitCilInstruction(visitor.ILVariable, OpCodes.Call, spanGetItemMethod);
             visitor.Visit(element);
-            //TODO: Why do we need to apply conversions? Isn´t visiting the element enough?
             context.TryApplyConversions(visitor.ILVariable, collectionExpressionOperation.Elements[index]);
             context.EmitCilInstruction(visitor.ILVariable, stindOpCode, targetElementType);
             index++;

--- a/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
+++ b/Cecilifier.Core/AST/CollectionExpressionProcessor.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Cecilifier.Core.CodeGeneration;
 using Cecilifier.Core.Extensions;
@@ -106,10 +104,12 @@ internal static class CollectionExpressionProcessor
         // Initializes the inline array
         context.EmitCilInstruction(visitor.ILVariable, OpCodes.Ldloca_S, inlineArrayLocalVar);
         context.EmitCilInstruction(visitor.ILVariable, OpCodes.Initobj, inlineArrayTypeVar);
-        
-        var inlineArrayElementRefMethodVar = PrivateImplementationDetailsGenerator
-                                                        .GetOrEmmitInlineArrayElementRefMethod(context)
-                                                        .MakeGenericInstanceMethod(context, "InlineArrayElementRef", [$"{inlineArrayLocalVar}.VariableType", context.TypeResolver.Resolve(spanTypeSymbol.TypeArguments[0])]);
+
+        var openInlineArrayElementRef = PrivateImplementationDetailsGenerator
+            .GetOrEmmitInlineArrayElementRefMethod(context);
+        var inlineArrayElementRefMethodVar = openInlineArrayElementRef
+            .VariableName
+            .MakeGenericInstanceMethod(context, openInlineArrayElementRef.MemberName, [$"{inlineArrayLocalVar}.VariableType", context.TypeResolver.Resolve(spanTypeSymbol.TypeArguments[0])]);
         
         var storeOpCode = inlineArrayElementType.StindOpCodeFor();
         var targetElementType = storeOpCode == OpCodes.Stobj ? context.TypeResolver.Resolve(inlineArrayElementType) : null; // Stobj expects the type of the object being stored.
@@ -127,9 +127,10 @@ internal static class CollectionExpressionProcessor
         }
         
         // convert the initialized InlineArray to a span and put it in the stack.
-        var inlineArrayAsSpanMethodVar = PrivateImplementationDetailsGenerator
-                                                    .GetOrEmmitInlineArrayAsSpanMethod(context)
-                                                    .MakeGenericInstanceMethod(context, "InlineArrayAsSpan", [$"{inlineArrayLocalVar}.VariableType", context.TypeResolver.Resolve(spanTypeSymbol.TypeArguments[0])]);
+        var openInlineArrayAsSpanVar = PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayAsSpanMethod(context);
+        var inlineArrayAsSpanMethodVar = openInlineArrayAsSpanVar
+                                            .VariableName
+                                            .MakeGenericInstanceMethod(context, openInlineArrayAsSpanVar.MemberName, [$"{inlineArrayLocalVar}.VariableType", context.TypeResolver.Resolve(spanTypeSymbol.TypeArguments[0])]);
         context.EmitCilInstruction(visitor.ILVariable, OpCodes.Ldloca_S, inlineArrayLocalVar);
         context.EmitCilInstruction(visitor.ILVariable, OpCodes.Ldc_I4, node.Elements.Count);
         context.EmitCilInstruction(visitor.ILVariable, OpCodes.Call, inlineArrayAsSpanMethodVar);
@@ -137,58 +138,7 @@ internal static class CollectionExpressionProcessor
 
     private static string GetOrEmitSyntheticInlineArrayFor(CollectionExpressionSyntax node, IVisitorContext context)
     {
-        context.WriteNewLine();
-        context.WriteComment($"Declares an inline array for backing the data for the collection expression: {node.SourceDetails()}");
-        
-        var typeVar = context.Naming.Type("", ElementKind.Struct);
-        var typeParameterVar = context.Naming.SyntheticVariable("TElementType", ElementKind.GenericParameter);
-
-        string[] typeExps = 
-        [
-            //[StructLayout(LayoutKind.Auto)]
-            $"""var {typeVar} = new TypeDefinition(string.Empty, "<>y_InlineArray{node.Elements.Count}`1", TypeAttributes.NotPublic | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Sealed, {context.TypeResolver.Bcl.System.ValueType});""",
-            CecilDefinitionsFactory.GenericParameter(context, $"{typeVar}.Name", typeVar, "TElementType", typeParameterVar),
-            $"""{typeVar}.GenericParameters.Add({typeParameterVar});"""
-        ];
-
-        var fieldVar = context.Naming.SyntheticVariable("_element0", ElementKind.Field);
-        var fieldExps = CecilDefinitionsFactory.Field(
-            context, 
-            $"{typeVar}.Name", 
-            typeVar,
-            fieldVar, 
-            "_element0", 
-            typeParameterVar, 
-            "FieldAttributes.Private");
-        
-        context.WriteCecilExpressions(typeExps);
-        
-        //[InlineArray(2)]
-        context.WriteCecilExpressions(
-            CecilDefinitionsFactory.Attribute(
-                "inlineArray", 
-                typeVar, 
-                context,
-                ConstructorFor<InlineArrayAttribute>(context, typeof(int)),
-                (context.TypeResolver.Bcl.System.Int32, node.Elements.Count.ToString())));
-        
-        context.WriteCecilExpressions(fieldExps);
-        context.AddCompilerGeneratedAttributeTo(fieldVar);
-        context.WriteCecilExpression($"assembly.MainModule.Types.Add({typeVar});\n");
-
-        return typeVar;
-    }
-
-    private static string ConstructorFor<TType>(IVisitorContext context, params Type[] ctorParamTypes)
-    {
-        var typeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(TType).FullName!).EnsureNotNull();
-        var ctors = typeSymbol.Constructors.Where(ctor => ctor.Parameters.Length == ctorParamTypes.Length);
-
-        if (ctors.Count() == 1)
-            return ctors.First().MethodResolverExpression(context);
-
-        var expectedParamTypes = ctorParamTypes.Select(paramType => context.SemanticModel.Compilation.GetTypeByMetadataName(paramType.FullName!)).ToHashSet(SymbolEqualityComparer.Default);
-        return ctors.Single(ctor => !ctor.Parameters.Select(p => p.Type).ToHashSet(SymbolEqualityComparer.Default).Except(expectedParamTypes, SymbolEqualityComparer.Default).Any()).MethodResolverExpression(context);
+        return InlineArrayGenerator.GetOrGenerateInlineArrayType(context, node.Elements.Count, $"Declares an inline array for backing the data for the collection expression: {node.SourceDetails()}");
     }
 
     private static void HandleAssignmentToArray(ExpressionVisitor visitor, CollectionExpressionSyntax node, IArrayTypeSymbol arrayTypeSymbol)

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -1281,7 +1281,7 @@ namespace Cecilifier.Core.AST
             if (!HandleLoadAddress(ilVar, type, expressionSyntax, OpCodes.Ldloca_S, tempLocalName))
             {
                 // HandleLoadAddress() does not handle scenarios in which a value type instantiation is passed as an 
-                // 'in parameter' to a method (that method is already complex so I don't want to make it even more
+                // 'in parameter' to a method (that method is already complex, so I don't want to make it even more
                 // complex)
                 Context.EmitCilInstruction(ilVar, RequiresAddressOfValue() ? OpCodes.Ldloca_S : OpCodes.Ldloc, tempLocalName);
             }

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -574,7 +574,7 @@ namespace Cecilifier.Core.AST
             var candidateSymbol = Context.SemanticModel.GetSymbolInfo(node.Parent!).Symbol.EnsureNotNull();
             if (candidateSymbol is IMethodSymbol method)
             {
-                _expandedParamsArgumentHandler = method.CreateExpandedParamsUsageHandler(Context, ilVar, node);
+                _expandedParamsArgumentHandler = method.CreateExpandedParamsUsageHandler(this, ilVar, node);
             }
             base.VisitArgumentList(node);
             _expandedParamsArgumentHandler?.PostProcessArgumentList(node);
@@ -1233,7 +1233,7 @@ namespace Cecilifier.Core.AST
             }
 
             Context.EmitCilInstruction(ilVar, OpCodes.Ldnull);
-            CecilDefinitionsFactory.InstantiateDelegate(Context, ilVar, Context.GetTypeInfo(node).ConvertedType, syntheticMethodVariable.VariableName, new StaticDelegateCacheContext
+            CecilDefinitionsFactory.InstantiateDelegate(Context, ilVar, Context.GetTypeInfo(node).ConvertedType!, syntheticMethodVariable.VariableName, new StaticDelegateCacheContext
             {
                 IsStaticDelegate = false
             });
@@ -1399,6 +1399,7 @@ namespace Cecilifier.Core.AST
                 Context.EmitCilInstruction(ilVar, OpCodes.Ldarg_0);
             }
 
+            Debug.Assert(delegateType != null);
             // we have a reference to a method used to initialize a delegate
             // and need to load the referenced method token and instantiate the delegate. For instance:
             //IL_0002: ldarg.0

--- a/Cecilifier.Core/AST/GlobalStatementHandler.cs
+++ b/Cecilifier.Core/AST/GlobalStatementHandler.cs
@@ -47,7 +47,7 @@ namespace Cecilifier.Core.AST
             var mainParametersExps = CecilDefinitionsFactory.Parameter(
                 "args",
                 RefKind.None,
-                false,
+                null,
                 methodVar,
                 paramVar,
                 $"{context.TypeResolver.Bcl.System.String}.MakeArrayType()",

--- a/Cecilifier.Core/AST/InlineArrayProcessor.cs
+++ b/Cecilifier.Core/AST/InlineArrayProcessor.cs
@@ -72,15 +72,14 @@ public class InlineArrayProcessor
             return PrivateImplementationInlineArrayGenericInstanceMethodFor(
                 context,
                 PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayAsSpanMethod(context),
-                "InlineArrayAsSpan",
                 inlineArrayType);
         }
     }
 
     /// <summary>
-    /// The expression 'InlineArray[range]' returns a sliced Span<T> where 'T' is the element type of the inline array.
-    /// All this method needs to do is to convert the inline array => Span<T> and use the same code that handles
-    /// 'indexing' a Span<T> with ranges.  
+    /// The expression 'InlineArray[range]' returns a sliced Span{T} where 'T' is the element type of the inline array.
+    /// All this method needs to do is to convert the inline array => Span{T} and use the same code that handles
+    /// 'indexing' a Span{T} with ranges.  
     /// </summary>
     internal static bool TryHandleRangeElementAccess(IVisitorContext context, ExpressionVisitor expressionVisitor, string ilVar, ElementAccessExpressionSyntax elementAccess, out ITypeSymbol elementType)
     {
@@ -123,7 +122,7 @@ public class InlineArrayProcessor
         ExpressionVisitor.Visit(context, ilVar, elementAccess.Expression);
         Debug.Assert(elementAccess.ArgumentList.Arguments.Count == 1);
 
-        var method = string.Empty;
+        string method;
         if (elementAccess.ArgumentList.Arguments[0].Expression.TryGetLiteralValueFor(out int index) && index == 0)
         {
             method = InlineArrayFirstElementRefMethodFor(context, inlineArrayType);
@@ -143,7 +142,6 @@ public class InlineArrayProcessor
             return PrivateImplementationInlineArrayGenericInstanceMethodFor(
                 context,
                 PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayFirstElementRefMethod(context),
-                "InlineArrayFirstElementRef",
                 inlineArrayType);
         }
         
@@ -152,16 +150,15 @@ public class InlineArrayProcessor
             return PrivateImplementationInlineArrayGenericInstanceMethodFor(
                 context,
                 PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayElementRefMethod(context),
-                "InlineArrayElementRef",
                 inlineArrayType);
         }
     }
     
-    private static string PrivateImplementationInlineArrayGenericInstanceMethodFor(IVisitorContext context, string openGenericTypeVar, string methodName, ITypeSymbol inlineArrayType)
+    static string PrivateImplementationInlineArrayGenericInstanceMethodFor(IVisitorContext context, DefinitionVariable openGenericTypeVar, ITypeSymbol inlineArrayType)
     {
-        var varName = openGenericTypeVar.MakeGenericInstanceMethod(
+        var varName = openGenericTypeVar.VariableName.MakeGenericInstanceMethod(
                                 context,
-                                methodName,
+                                openGenericTypeVar.MemberName,
                                 [
                                     context.TypeResolver.Resolve(inlineArrayType), // TBuffer
                                     context.TypeResolver.Resolve(InlineArrayElementTypeFrom(inlineArrayType)) // TElement

--- a/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/MethodDeclarationVisitor.cs
@@ -91,7 +91,7 @@ namespace Cecilifier.Core.AST
 
             var methodVar = Context.DefinitionVariables.GetLastOf(VariableMemberKind.Method);
             if (!methodVar.IsValid)
-                throw new InvalidOperationException($"Failed to retrieve current method.");
+                throw new InvalidOperationException("Failed to retrieve current method.");
 
             using var _ = LineInformationTracker.Track(Context, node);
             

--- a/Cecilifier.Core/AST/NonCapturingLambdaProcessor.cs
+++ b/Cecilifier.Core/AST/NonCapturingLambdaProcessor.cs
@@ -82,7 +82,7 @@ namespace Cecilifier.Core.AST
                 var paramExps = CecilDefinitionsFactory.Parameter(
                     parameter.Identifier.Text,
                     RefKind.None,
-                    isParams: false,
+                    paramsAttributeTypeName: null,
                     methodVar,
                     context.Naming.SyntheticVariable(parameter.Identifier.Text, ElementKind.Parameter),
                     resolvedParamType,

--- a/Cecilifier.Core/AST/NullLiteralArgumentDecorator.cs
+++ b/Cecilifier.Core/AST/NullLiteralArgumentDecorator.cs
@@ -12,7 +12,7 @@ namespace Cecilifier.Core.AST;
 /// A `Disposable` type used to emit code to handle passing null as arguments to parameters typed as Nullable{T} 
 /// </summary>
 /// <remarks>
-/// Since Nullable{T} is a struct passing `null` as an argument the code needs to:
+/// Since Nullable{T} is a struct, passing `null` as an argument the code needs to:
 /// 1. Add a synthetic local variable
 /// 2. Loads it address to stack
 /// 3. Execute InitObj instruction

--- a/Cecilifier.Core/AST/Params/ArrayExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/ArrayExpandedParamsArgumentHandler.cs
@@ -25,11 +25,6 @@ internal class ArrayExpandedParamsArgumentHandler : ExpandedParamsArgumentHandle
     private OpCode _stelemOpCode;
     private string _backingVariableName;
 
-    /// <summary>
-    /// Callback used to pre-process argument handling. It can be used to inject code
-    /// before the code generation for each argument.
-    /// </summary>
-    /// <param name="argument">Argument being processed.</param>
     internal override void PreProcessArgument(ArgumentSyntax argument)
     {
         var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);
@@ -47,11 +42,6 @@ internal class ArrayExpandedParamsArgumentHandler : ExpandedParamsArgumentHandle
         Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, _currentIndex++);
     }
 
-    /// <summary>
-    /// Callback used to post-process argument handling. It can be used to inject code
-    /// *after* generating code for each attribute.
-    /// </summary>
-    /// <param name="argument">Argument being processed.</param>
     internal override void PostProcessArgument(ArgumentSyntax argument)
     {
         var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);

--- a/Cecilifier.Core/AST/Params/ArrayExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/ArrayExpandedParamsArgumentHandler.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System.Diagnostics;
+using Cecilifier.Core.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mono.Cecil.Cil;
+
+namespace Cecilifier.Core.AST.Params;
+
+internal class ArrayExpandedParamsArgumentHandler : ExpandedParamsArgumentHandler
+{
+    public ArrayExpandedParamsArgumentHandler(IVisitorContext context, IParameterSymbol paramsParameter, ArgumentListSyntax argumentList, string ilVar) : base(context, paramsParameter, argumentList, ilVar)
+    {
+        _currentIndex = 0;
+        _stelemOpCode = ElementType.StelemOpCode();
+        
+        _backingVariableName = Context.AddLocalVariableToCurrentMethod($"{paramsParameter.Name}Params", Context.TypeResolver.Resolve(paramsParameter.Type));
+        
+        var paramsType = Context.TypeResolver.Resolve(ElementType);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, ElementCount);
+        Context.EmitCilInstruction(ilVar, OpCodes.Newarr, paramsType);
+        Context.EmitCilInstruction(ilVar, OpCodes.Stloc, _backingVariableName);
+    }
+
+    private OpCode _stelemOpCode;
+    private string _backingVariableName;
+
+    /// <summary>
+    /// Callback used to pre-process argument handling. It can be used to inject code
+    /// before the code generation for each argument.
+    /// </summary>
+    /// <param name="argument">Argument being processed.</param>
+    internal override void PreProcessArgument(ArgumentSyntax argument)
+    {
+        var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);
+        Debug.Assert(argumentIndex >= 0);
+
+        if (argumentIndex < FirstArgumentIndex)
+            return;
+                
+        if (argumentIndex == FirstArgumentIndex)
+        {
+            Context.EmitCilInstruction(ilVar, OpCodes.Ldloc, _backingVariableName);
+        }
+                
+        Context.EmitCilInstruction(ilVar, OpCodes.Dup);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, _currentIndex++);
+    }
+
+    /// <summary>
+    /// Callback used to post-process argument handling. It can be used to inject code
+    /// *after* generating code for each attribute.
+    /// </summary>
+    /// <param name="argument">Argument being processed.</param>
+    internal override void PostProcessArgument(ArgumentSyntax argument)
+    {
+        var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);
+        Debug.Assert(argumentIndex >= 0);
+
+        if (argumentIndex < FirstArgumentIndex)
+            return;
+                
+        Context.EmitCilInstruction(ilVar, _stelemOpCode);
+    }
+}

--- a/Cecilifier.Core/AST/Params/ExpandedParamsArgumentContext.cs
+++ b/Cecilifier.Core/AST/Params/ExpandedParamsArgumentContext.cs
@@ -1,0 +1,112 @@
+#nullable enable
+using System.Diagnostics;
+using Cecilifier.Core.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mono.Cecil.Cil;
+
+namespace Cecilifier.Core.AST.Params;
+
+/// <summary>
+/// Handles specifics of expanded params argument passing. You can read more details about <see href="">expanded/non-expanded forms</see>.
+///
+/// When calling methods with `params` parameters users can either pass 1) an array (non-expanded form) or 2) the actual values (expanded form)
+///
+/// Examples assuming the method below:
+/// <code>
+/// void M(params int[] ints) { }
+/// </code>
+/// 
+/// 1) Non-Expanded:  M(new [] { 1, 2, 3});
+/// 2) Expanded: M(1, 2, 3);
+/// </summary>
+internal class ExpandedParamsArgumentContext
+{
+    public ExpandedParamsArgumentContext(IVisitorContext context, IParameterSymbol paramsParameter, ArgumentListSyntax argumentList, string ilVar)
+    {
+        Context = context;
+        BackingVariableName = Context.AddLocalVariableToCurrentMethod($"{paramsParameter.Name}Params", Context.TypeResolver.Resolve(paramsParameter.Type));
+        ElementType = paramsParameter.Type.ElementTypeSymbolOf(); 
+        FirstArgumentIndex = paramsParameter.Ordinal;
+        ElementCount = argumentList.Arguments.Count - paramsParameter.Ordinal;
+        ParentArgumentList = argumentList;
+        this.ilVar = ilVar;
+        _currentIndex = 0;
+        _stelemOpCode = ElementType.StelemOpCode();
+    }
+
+    private IVisitorContext Context { get; }
+    
+    /// <summary>
+    /// The index of the first argument in an invocation that is part os the list of values included in the `params`.
+    /// For example, in the following code:
+    /// <code>
+    /// void M(string s, params int[] ints) {}
+    ///
+    /// M("Test",  42, 1);
+    /// </code>
+    /// the first argument in the invocation of method `M` that is part of `ints` params is the number 42 which has index 1,
+    /// so in this case <see cref="FirstArgumentIndex"/> is set to `1` 
+    /// </summary>
+    private int FirstArgumentIndex { get; }
+    
+    /// <summary>
+    /// Number of elements in the expanded form that is part of the `params` parameter. Given the following code:
+    /// <code>
+    /// void M(string s, params int[] ints) {}
+    ///
+    /// M("Test",  42, 1, 10);
+    /// </code>
+    /// <see cref="ElementCount"/> will be set to 3.
+    /// </summary>
+    public int ElementCount { get; }
+    public ITypeSymbol ElementType { get; }
+    public string BackingVariableName { get; }
+    
+    /// <summary>
+    /// The syntax node containing the arguments used in the invocation.
+    /// </summary>
+    private ArgumentListSyntax ParentArgumentList { get; }
+            
+    private readonly string ilVar;
+    private int _currentIndex;
+    private OpCode _stelemOpCode; 
+
+    /// <summary>
+    /// Callback used to pre-process argument handling. It can be used to inject code
+    /// before the code generation for each argument.
+    /// </summary>
+    /// <param name="argument">Argument being processed.</param>
+    internal void PreProcessArgument(ArgumentSyntax argument)
+    {
+        var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);
+        Debug.Assert(argumentIndex >= 0);
+
+        if (argumentIndex < FirstArgumentIndex)
+            return;
+                
+        if (argumentIndex == FirstArgumentIndex)
+        {
+            Context.EmitCilInstruction(ilVar, OpCodes.Ldloc, BackingVariableName);
+        }
+                
+        Context.EmitCilInstruction(ilVar, OpCodes.Dup);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, _currentIndex++);
+    }
+
+    /// <summary>
+    /// Callback used to post-process argument handling. It can be used to inject code
+    /// *after* generating code for each attribute.
+    /// </summary>
+    /// <param name="argument">Argument being processed.</param>
+    internal void PostProcessArgument(ArgumentSyntax argument)
+    {
+        var argumentIndex = ParentArgumentList.Arguments.IndexOf(argument);
+        Debug.Assert(argumentIndex >= 0);
+
+        if (argumentIndex < FirstArgumentIndex)
+            return;
+                
+        Context.EmitCilInstruction(ilVar, _stelemOpCode);
+    }
+}

--- a/Cecilifier.Core/AST/Params/ExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/ExpandedParamsArgumentHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Cecilifier.Core.AST.Params;
 
 /// <summary>
-/// Handles specifics of expanded params argument passing. You can read more details about <see href="">expanded/non-expanded forms</see>.
+/// Handles specifics of expanded params argument passing. You can read more details about <see href="https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12642-applicable-function-member">expanded/non-expanded forms</see>.
 ///
 /// When calling methods with `params` parameters users can either pass 1) an array (non-expanded form) or 2) the actual values (expanded form)
 ///
@@ -16,7 +16,12 @@ namespace Cecilifier.Core.AST.Params;
 /// </code>
 /// 
 /// 1) Non-Expanded:  M(new [] { 1, 2, 3});
-/// 2) Expanded: M(1, 2, 3);
+/// 2) Expanded: M(4 5, 6);
+///
+/// <remarks>
+/// When invoked with the expanded form Cecilifier needs to create a variable to hold the argument values. In the example above a new array of
+/// length 3 need to be allocated and initialized with values 4, 5 and 6.
+/// </remarks>
 /// </summary>
 internal abstract class ExpandedParamsArgumentHandler
 {
@@ -77,7 +82,7 @@ internal abstract class ExpandedParamsArgumentHandler
 
     /// <summary>
     /// Callback used to post-process argument handling. It can be used to inject code
-    /// *after* generating code for each attribute.
+    /// *after* generating code that process each argument in the expanded params items.
     /// </summary>
     /// <param name="argument">Argument being processed.</param>
     internal abstract void PostProcessArgument(ArgumentSyntax argument);

--- a/Cecilifier.Core/AST/Params/ListBackedExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/ListBackedExpandedParamsArgumentHandler.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Misc;
+using Cecilifier.Core.Variables;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mono.Cecil.Cil;
+
+namespace Cecilifier.Core.AST.Params;
+
+internal class ListBackedExpandedParamsArgumentHandler : ExpandedParamsArgumentHandler
+{
+    private readonly DefinitionVariable spanWrappingListVariable;
+    private int index;
+    private readonly OpCode stIndOpCodeToUse;
+    private readonly string targetElementTypeWhenStoring;
+    private readonly string spanIndexerGetter;
+    
+    public ListBackedExpandedParamsArgumentHandler(ExpressionVisitor expressionVisitor, IParameterSymbol paramsParameter, ArgumentListSyntax argumentList) : base(expressionVisitor.Context, paramsParameter, argumentList, expressionVisitor.ILVariable)
+    {
+        var elements = argumentList.Arguments.Select(arg => Context.SemanticModel.GetOperation(arg.Expression));
+        var elementType = ((INamedTypeSymbol) paramsParameter.Type).TypeArguments[0];
+        var openListType = Context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(List<>).FullName!).EnsureNotNull();
+        (spanWrappingListVariable, var resolvedListTypeArgument) = CecilDefinitionsFactory.Collections.InstantiateListToStoreElements(expressionVisitor.Context, expressionVisitor.ILVariable, openListType.Construct(elementType), elements.Count());
+        
+        Context.WriteNewLine();
+        Context.WriteComment($"Initialize each list element through the span (variable '{spanWrappingListVariable.VariableName}')");
+        stIndOpCodeToUse = elementType.StindOpCodeFor();
+        targetElementTypeWhenStoring = stIndOpCodeToUse == OpCodes.Stobj ? resolvedListTypeArgument : null; // Stobj expects the type of the object being stored.
+
+        spanIndexerGetter = CecilDefinitionsFactory.Collections.GetSpanIndexerGetter(Context, resolvedListTypeArgument);
+    }
+
+    internal override void PreProcessArgument(ArgumentSyntax argument)
+    {
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldloca_S, spanWrappingListVariable.VariableName);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, index++);
+        Context.EmitCilInstruction(ilVar, OpCodes.Call, spanIndexerGetter);
+    }
+
+    internal override void PostProcessArgument(ArgumentSyntax argument)
+    { 
+        Context.EmitCilInstruction(ilVar, stIndOpCodeToUse, targetElementTypeWhenStoring);
+    }
+}

--- a/Cecilifier.Core/AST/Params/ReadOnlySpanExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/ReadOnlySpanExpandedParamsArgumentHandler.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using Cecilifier.Core.CodeGeneration;
+using Cecilifier.Core.Variables;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cecilifier.Core.AST.Params;
+
+internal class ReadOnlySpanExpandedParamsArgumentHandler : SpanExpandedParamsArgumentHandler
+{
+    public ReadOnlySpanExpandedParamsArgumentHandler(IVisitorContext context, IParameterSymbol paramsParameter, ArgumentListSyntax argumentList, string ilVar) 
+        : base(context, paramsParameter, argumentList, ilVar)
+    {
+    }
+
+    protected override DefinitionVariable GetInlineArrayToSpanResolvedMethod() => PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayAsReadOnlySpanMethod(Context);
+}

--- a/Cecilifier.Core/AST/Params/SpanExpandedParamsArgumentHandler.cs
+++ b/Cecilifier.Core/AST/Params/SpanExpandedParamsArgumentHandler.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using Cecilifier.Core.CodeGeneration;
+using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Variables;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mono.Cecil.Cil;
+
+namespace Cecilifier.Core.AST.Params;
+
+internal class SpanExpandedParamsArgumentHandler : ExpandedParamsArgumentHandler
+{
+    private readonly string _inlineArrayVariableName;
+    private readonly OpCode _stindOpCode;
+    private readonly string _inlineArrayType;
+    private readonly ITypeSymbol _paramsParameterType;
+
+    public SpanExpandedParamsArgumentHandler(IVisitorContext context, IParameterSymbol paramsParameter, ArgumentListSyntax argumentList, string ilVar) : base(context, paramsParameter, argumentList, ilVar)
+    {
+        _paramsParameterType = paramsParameter.Type.ElementTypeSymbolOf();
+        _stindOpCode = _paramsParameterType.StindOpCodeFor();
+        
+        var openInlineArrayType = InlineArrayGenerator.GetOrGenerateInlineArrayType(context, argumentList.Arguments.Count, "InlineArray to store the `params` values.");
+        _inlineArrayType = openInlineArrayType.MakeGenericInstanceType([context.TypeResolver.Resolve(_paramsParameterType)]);
+
+        var inlineArrayBuffer = context.AddLocalVariableToCurrentMethod($"{paramsParameter.Name}Arg", _inlineArrayType);
+        _inlineArrayVariableName = inlineArrayBuffer.VariableName;
+        
+        context.EmitCilInstruction(ilVar, OpCodes.Ldloca_S, _inlineArrayVariableName);
+        context.EmitCilInstruction(ilVar, OpCodes.Initobj, _inlineArrayType);
+    }
+
+    internal override void PreProcessArgument(ArgumentSyntax argument)
+    {
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldloca_S, _inlineArrayVariableName);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, _currentIndex++);
+        var openInlineArrayElementRefMethod = PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayElementRefMethod(Context);
+
+        Context.EmitCilInstruction(ilVar, OpCodes.Call, MakeGenericInstanceMethod(openInlineArrayElementRefMethod));
+    }
+
+    internal override void PostProcessArgument(ArgumentSyntax argument)
+    {
+        Context.EmitCilInstruction(ilVar, _stindOpCode);
+    }
+
+    public override void PostProcessArgumentList(ArgumentListSyntax argumentList)
+    {
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldloca_S, _inlineArrayVariableName);
+        Context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, ElementCount);
+        
+        // gets a Span<T> from the inline array
+        Context.EmitCilInstruction(ilVar, OpCodes.Call, MakeGenericInstanceMethod(GetInlineArrayToSpanResolvedMethod()));
+    }
+
+    protected virtual DefinitionVariable GetInlineArrayToSpanResolvedMethod() => PrivateImplementationDetailsGenerator.GetOrEmmitInlineArrayAsSpanMethod(Context);
+    
+    string MakeGenericInstanceMethod(DefinitionVariable genericMethodVariable)
+    {
+        return genericMethodVariable.VariableName.MakeGenericInstanceMethod(Context, genericMethodVariable.MemberName, [ _inlineArrayType, Context.TypeResolver.Resolve(_paramsParameterType)]);
+    }
+}

--- a/Cecilifier.Core/AST/StatementVisitor.ForEach.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.ForEach.cs
@@ -127,7 +127,7 @@ namespace Cecilifier.Core.AST
             Context.EmitCilInstruction(_ilVar, loadOpCode, forEachHandlerContext.EnumeratorVariableName);
             Context.AddCallToMethod(forEachHandlerContext.EnumeratorCurrentProperty.GetMethod, _ilVar, MethodDispatchInformation.MostLikelyVirtual);
 
-            if (!node.Type.IsKind(SyntaxKind.RefType) && forEachHandlerContext.EnumeratorCurrentProperty.ReturnsByRef)
+            if (!node.Type.IsKind(SyntaxKind.RefType) && forEachHandlerContext.EnumeratorCurrentProperty.IsByRef())
             {
                 Context.EmitCilInstruction(_ilVar, forEachHandlerContext.EnumeratorCurrentProperty.Type.LdindOpCodeFor());
             }

--- a/Cecilifier.Core/AST/StatementVisitor.cs
+++ b/Cecilifier.Core/AST/StatementVisitor.cs
@@ -304,7 +304,7 @@ namespace Cecilifier.Core.AST
             return Context.AddLocalVariableToMethod(localVar.Identifier.Text, methodVar, resolvedVarType);
         }
 
-        private void ProcessVariableInitialization(VariableDeclaratorSyntax localVar, ITypeSymbol? variableType)
+        private void ProcessVariableInitialization(VariableDeclaratorSyntax localVar, ITypeSymbol variableType)
         {
             if (localVar.Initializer == null)
                 return;
@@ -319,7 +319,7 @@ namespace Cecilifier.Core.AST
             // the same applies if...
             var isDefaultLiteralExpressionOnNonPrimitiveValueType = localVar.Initializer.Value.IsKind(SyntaxKind.DefaultLiteralExpression) && variableType is { IsValueType: true } && !variableType.IsPrimitiveType();
             var isNullAssignmentToNullableValueType = localVar.Initializer is EqualsValueClauseSyntax { Value: LiteralExpressionSyntax { RawKind: (int) SyntaxKind.NullLiteralExpression } }
-                                                      && SymbolEqualityComparer.Default.Equals(variableType?.OriginalDefinition, Context.RoslynTypeSystem.SystemNullableOfT);
+                                                      && SymbolEqualityComparer.Default.Equals(variableType.OriginalDefinition, Context.RoslynTypeSystem.SystemNullableOfT);
 
             if (isIndexExpression || isDefaultLiteralExpressionOnNonPrimitiveValueType || isNullAssignmentToNullableValueType)
             {
@@ -331,7 +331,7 @@ namespace Cecilifier.Core.AST
                 return;
             }
 
-            var valueBeingAssignedIsByRef = Context.SemanticModel.GetSymbolInfo(localVar.Initializer.Value).Symbol.IsByRef();
+            var valueBeingAssignedIsByRef = Context.SemanticModel.GetSymbolInfo(localVar.Initializer.Value).Symbol!.IsByRef();
             if (!variableType.IsByRef() && valueBeingAssignedIsByRef)
             {
                 OpCode opCode = variableType.LdindOpCodeFor();
@@ -349,7 +349,7 @@ namespace Cecilifier.Core.AST
             {
                 var declaredVariable = AddLocalVariable(declaration.Type, localVar, methodVar);
                 using var _ = Context.DefinitionVariables.WithVariable(declaredVariable);
-                ProcessVariableInitialization(localVar, variableType.Type);
+                ProcessVariableInitialization(localVar, variableType.Type!);
             }
         }
 

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -458,6 +458,7 @@ namespace Cecilifier.Core.AST
             var opCode = fieldSymbol.LoadOpCodeForFieldAccess();
             Context.EmitCilInstruction(ilVar, opCode, resolvedFieldVariable);
             HandlePotentialDelegateInvocationOn(node, fieldSymbol.Type, ilVar);
+            HandlePotentialRefLoad(ilVar, node, fieldSymbol.Type);
         }
 
         protected void ProcessLocalVariable(string ilVar, SimpleNameSyntax localVarSyntax, ILocalSymbol symbol)

--- a/Cecilifier.Core/AST/SyntaxWalkerBase.cs
+++ b/Cecilifier.Core/AST/SyntaxWalkerBase.cs
@@ -673,7 +673,12 @@ namespace Cecilifier.Core.AST
                     _ => throw new NotImplementedException($"Found not supported symbol {symbol.ToDisplayString()} ({symbol.GetType().Name}) when trying to find index of argument ({argument})")
                 };
 
-                return method.Parameters[argumentIndex];
+                Debug.Assert(method != null);
+                if (method.Parameters.Length > argumentIndex)
+                    return method.Parameters[argumentIndex];
+                        
+                Debug.Assert(method.Parameters.Last().IsParams);
+                return method.Parameters.Last();
             }
 
             var elementAccess = argument.Ancestors().OfType<ElementAccessExpressionSyntax>().SingleOrDefault();

--- a/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
+++ b/Cecilifier.Core/AST/TypeDeclarationVisitor.Delegate.cs
@@ -90,7 +90,7 @@ internal partial class TypeDeclarationVisitor
             var endInvokeParamExps = CecilDefinitionsFactory.Parameter(
                 "ar",
                 RefKind.None,
-                false,
+                paramsAttributeTypeName: null,
                 endInvokeMethodVar,
                 Context.Naming.Parameter("ar"),
                 Context.TypeResolver.Bcl.System.IAsyncResult,

--- a/Cecilifier.Core/Cecilifier.cs
+++ b/Cecilifier.Core/Cecilifier.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Cecilifier.Core.AST;
+using Cecilifier.Core.CodeGeneration;
 using Cecilifier.Core.Extensions;
 using Cecilifier.Core.Mappings;
 using Cecilifier.Core.Misc;
@@ -20,6 +21,7 @@ namespace Cecilifier.Core
 
         public static CecilifierResult Process(Stream content, CecilifierOptions options)
         {
+            InlineArrayGenerator.Reset();
             UsageVisitor.ResetInstance();
             using var stream = new StreamReader(content);
             var syntaxTree = CSharpSyntaxTree.ParseText(stream.ReadToEnd(), new CSharpParseOptions(CurrentLanguageVersion));

--- a/Cecilifier.Core/CodeGeneration/InlineArray.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/InlineArray.Generator.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Cecilifier.Core.AST;
+using Cecilifier.Core.Extensions;
+using Cecilifier.Core.Misc;
+using Cecilifier.Core.Naming;
+using Microsoft.CodeAnalysis;
+
+namespace Cecilifier.Core.CodeGeneration;
+
+internal class InlineArrayGenerator
+{
+    internal static void Reset() => _typeVariablePerElementCount.Clear();
+    public static string GetOrGenerateInlineArrayType(IVisitorContext context, int elementCount, string comment)
+    {
+        ref var typeVar = ref CollectionsMarshal.GetValueRefOrAddDefault(_typeVariablePerElementCount, elementCount, out var exists)!;
+        if (!exists)
+        {
+            context.WriteNewLine();
+            context.WriteComment(comment);
+            
+            typeVar = context.Naming.Type("inlineArray", ElementKind.Struct);
+            var typeParameterVar = context.Naming.SyntheticVariable("TElementType", ElementKind.GenericParameter);
+
+            string[] typeExps = 
+            [
+                //[StructLayout(LayoutKind.Auto)]
+                $"""var {typeVar} = new TypeDefinition(string.Empty, "<>y_InlineArray{elementCount}`1", TypeAttributes.NotPublic | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Sealed, {context.TypeResolver.Bcl.System.ValueType});""",
+                CecilDefinitionsFactory.GenericParameter(context, $"{typeVar}.Name", typeVar, "TElementType", typeParameterVar),
+                $"""{typeVar}.GenericParameters.Add({typeParameterVar});"""
+            ];
+
+            var fieldVar = context.Naming.SyntheticVariable("_element0", ElementKind.Field);
+            var fieldExps = CecilDefinitionsFactory.Field(
+                context, 
+                $"{typeVar}.Name", 
+                typeVar,
+                fieldVar, 
+                "_element0", 
+                typeParameterVar, 
+                "FieldAttributes.Private");
+            
+            context.WriteCecilExpressions(typeExps);
+            
+            //[InlineArray(2)]
+            context.WriteCecilExpressions(
+                CecilDefinitionsFactory.Attribute(
+                    "inlineArray", 
+                    typeVar, 
+                    context,
+                    ConstructorFor<InlineArrayAttribute>(context, typeof(int)),
+                    (context.TypeResolver.Bcl.System.Int32, elementCount.ToString())));
+            
+            context.WriteCecilExpressions(fieldExps);
+            context.AddCompilerGeneratedAttributeTo(fieldVar);
+            context.WriteCecilExpression($"assembly.MainModule.Types.Add({typeVar});\n");
+        }
+        
+        return typeVar;
+    }
+    
+    private static string ConstructorFor<TType>(IVisitorContext context, params Type[] ctorParamTypes)
+    {
+        var typeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(TType).FullName!).EnsureNotNull();
+        var ctors = typeSymbol.Constructors.Where(ctor => ctor.Parameters.Length == ctorParamTypes.Length);
+
+        if (ctors.Count() == 1)
+            return ctors.First().MethodResolverExpression(context);
+
+        var expectedParamTypes = ctorParamTypes.Select(paramType => context.SemanticModel.Compilation.GetTypeByMetadataName(paramType.FullName!)).ToHashSet(SymbolEqualityComparer.Default);
+        return ctors.Single(ctor => !ctor.Parameters.Select(p => p.Type).ToHashSet(SymbolEqualityComparer.Default).Except(expectedParamTypes, SymbolEqualityComparer.Default).Any()).MethodResolverExpression(context);
+    }
+    
+    private static Dictionary<int, string> _typeVariablePerElementCount = new();
+}

--- a/Cecilifier.Core/CodeGeneration/PrimaryConstructor.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/PrimaryConstructor.Generator.cs
@@ -146,7 +146,7 @@ public class PrimaryConstructorGenerator
             context.WriteComment($"Parameter: {parameter.Identifier}");
             var paramVar = context.Naming.Parameter(parameter);
             var parameterType = context.TypeResolver.Resolve(ModelExtensions.GetTypeInfo(context.SemanticModel, parameter.Type!).Type);
-            var paramExps = CecilDefinitionsFactory.Parameter(parameter.Identifier.ValueText, RefKind.None, false, ctorVar, paramVar, parameterType, Constants.ParameterAttributes.None, ("", false));
+            var paramExps = CecilDefinitionsFactory.Parameter(parameter.Identifier.ValueText, RefKind.None, null, ctorVar, paramVar, parameterType, Constants.ParameterAttributes.None, ("", false));
             context.WriteCecilExpressions(paramExps);
 
             if (!uniqueParameters.Contains(parameter))

--- a/Cecilifier.Core/CodeGeneration/PrivateImplementationDetails.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/PrivateImplementationDetails.Generator.cs
@@ -1,10 +1,10 @@
+#nullable enable annotations
+
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
 using System.Security.Cryptography;
 using System.Text;
 using Cecilifier.Core.AST;
@@ -46,11 +46,11 @@ namespace Cecilifier.Core.CodeGeneration;
  */
 internal partial class PrivateImplementationDetailsGenerator
 {
-    internal static string GetOrEmmitInlineArrayAsSpanMethod(IVisitorContext context)
+    internal static DefinitionVariable GetOrEmmitInlineArrayAsSpanMethod(IVisitorContext context)
     {
         var found = context.DefinitionVariables.GetVariable("InlineArrayAsSpan", VariableMemberKind.Method, Constants.CompilerGeneratedTypes.PrivateImplementationDetails);
         if (found.IsValid)
-            return found.VariableName;
+            return found;
         
         var privateImplementationDetailsVar = GetOrCreatePrivateImplementationDetailsTypeVariable(context);
         
@@ -76,7 +76,7 @@ internal partial class PrivateImplementationDetailsGenerator
                                                             var spanTypeParameter = ResolveOwnedGenericParameter(context, "TElement", methodTypeQualifiedName);
                                                             return context.TypeResolver.Resolve(context.RoslynTypeSystem.SystemSpan).MakeGenericInstanceType(spanTypeParameter);
                                                         },
-                                                        out _);
+                                                        out var methodDefinitionVariable);
 
         context.WriteCecilExpressions(methodExpressions);
         
@@ -105,7 +105,7 @@ internal partial class PrivateImplementationDetailsGenerator
         var finalExps = methodBodyExpressions.Append($"{privateImplementationDetailsVar.VariableName}.Methods.Add({methodVar});");
         context.WriteCecilExpressions(finalExps);
         
-        return methodVar;
+        return methodDefinitionVariable;
         
         static IMethodSymbol GetMemoryMarshalCreateSpanMethod(IVisitorContext context)
         {
@@ -130,11 +130,11 @@ internal partial class PrivateImplementationDetailsGenerator
         }
     }
     
-    public static string GetOrEmmitInlineArrayFirstElementRefMethod(IVisitorContext context)
+    public static DefinitionVariable GetOrEmmitInlineArrayFirstElementRefMethod(IVisitorContext context)
     {
         var found = context.DefinitionVariables.GetVariable("InlineArrayFirstElementRef", VariableMemberKind.Method, Constants.CompilerGeneratedTypes.PrivateImplementationDetails);
         if (found.IsValid)
-            return found.VariableName;
+            return found;
         
         var privateImplementationDetailsVar = GetOrCreatePrivateImplementationDetailsTypeVariable(context);
         
@@ -157,7 +157,7 @@ internal partial class PrivateImplementationDetailsGenerator
                                                             var spanTypeParameter = ResolveOwnedGenericParameter(ctx, "TElement", methodTypeQualifiedName);
                                                             return spanTypeParameter.MakeByReferenceType();
                                                         },
-                                                        out _);
+                                                        out var methodDefinitionVariable);
 
         context.WriteCecilExpressions(methodExpressions);
         
@@ -185,14 +185,14 @@ internal partial class PrivateImplementationDetailsGenerator
         context.WriteNewLine();
         context.WriteComment("-------------------------------");
         context.WriteNewLine();
-        return methodVar;
+        return methodDefinitionVariable;
     }
     
-    public static string GetOrEmmitInlineArrayElementRefMethod(IVisitorContext context)
+    public static DefinitionVariable GetOrEmmitInlineArrayElementRefMethod(IVisitorContext context)
     {
         var found = context.DefinitionVariables.GetVariable("InlineArrayElementRef", VariableMemberKind.Method, Constants.CompilerGeneratedTypes.PrivateImplementationDetails);
         if (found.IsValid)
-            return found.VariableName;
+            return found;
         
         var privateImplementationDetailsVar = GetOrCreatePrivateImplementationDetailsTypeVariable(context);
         
@@ -218,7 +218,7 @@ internal partial class PrivateImplementationDetailsGenerator
                                                             var spanTypeParameter = ResolveOwnedGenericParameter(ctx, "TElement", methodTypeQualifiedName);
                                                             return spanTypeParameter.MakeByReferenceType();
                                                         },
-                                                        out _);
+                                                        out var methodDefinitionVariable);
 
         context.WriteCecilExpressions(methodExpressions);
         
@@ -252,7 +252,7 @@ internal partial class PrivateImplementationDetailsGenerator
         context.WriteComment("-------------------------------");
         context.WriteNewLine();
         
-        return methodVar;
+        return methodDefinitionVariable;
     }
     
     private static string ResolveOwnedGenericParameter(IVisitorContext context, string name, string methodTypeQualifiedName)
@@ -372,7 +372,7 @@ internal partial class PrivateImplementationDetailsGenerator
         
         context.WriteNewLine();
         context.WriteComment($"{Constants.CompilerGeneratedTypes.PrivateImplementationDetails} class.");
-        context.WriteComment($"This type is emitted by the compiler.");
+        context.WriteComment("This type is emitted by the compiler.");
         
         var privateImplementationDetailsVar = context.Naming.Type("privateImplementationDetails", ElementKind.Class);
         var privateImplementationDetails = CecilDefinitionsFactory.Type(

--- a/Cecilifier.Core/CodeGeneration/Record.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/Record.Generator.cs
@@ -124,7 +124,7 @@ internal partial class RecordGenerator
             context.WriteCecilExpressions(
             [
                 copyCtor,
-                ..CecilDefinitionsFactory.Parameter("other", RefKind.None, false, copyCtorVar, context.Naming.Parameter("other"), context.TypeResolver.Resolve(_recordSymbol), Constants.ParameterAttributes.None, (null, false))
+                ..CecilDefinitionsFactory.Parameter("other", RefKind.None, null, copyCtorVar, context.Naming.Parameter("other"), context.TypeResolver.Resolve(_recordSymbol), Constants.ParameterAttributes.None, (null, false))
             ]);
         }
 

--- a/Cecilifier.Core/Extensions/FieldExtensions.cs
+++ b/Cecilifier.Core/Extensions/FieldExtensions.cs
@@ -16,8 +16,8 @@ namespace Cecilifier.Core.Extensions
                 var found = context.DefinitionVariables.GetVariable(field.Name, VariableMemberKind.Field, field.ContainingType.OriginalDefinition.ToDisplayString());
                 ThrowIfVariableNotFound(found.IsValid);
 
-                var resolvedField = field.ContainingType.IsGenericType// && !field.ContainingType.IsDefinition 
-                    ? $$"""new FieldReference("{{field.Name}}", {{context.TypeResolver.Resolve(field.OriginalDefinition.Type)}}, {{context.TypeResolver.Resolve(field.ContainingType)}})""" 
+                var resolvedField = field.ContainingType.IsGenericType
+                    ? $$"""new FieldReference({{found.VariableName}}.Name, {{found.VariableName}}.FieldType, {{context.TypeResolver.Resolve(field.ContainingType)}})""" 
                     : found.VariableName;
                 
                 return resolvedField;

--- a/Cecilifier.Core/Extensions/FieldExtensions.cs
+++ b/Cecilifier.Core/Extensions/FieldExtensions.cs
@@ -16,7 +16,7 @@ namespace Cecilifier.Core.Extensions
                 var found = context.DefinitionVariables.GetVariable(field.Name, VariableMemberKind.Field, field.ContainingType.OriginalDefinition.ToDisplayString());
                 ThrowIfVariableNotFound(found.IsValid);
 
-                var resolvedField = field.ContainingType.IsGenericType && !field.ContainingType.IsDefinition 
+                var resolvedField = field.ContainingType.IsGenericType// && !field.ContainingType.IsDefinition 
                     ? $$"""new FieldReference("{{field.Name}}", {{context.TypeResolver.Resolve(field.OriginalDefinition.Type)}}, {{context.TypeResolver.Resolve(field.ContainingType)}})""" 
                     : found.VariableName;
                 

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -285,6 +285,12 @@ namespace Cecilifier.Core.Extensions
                 return null;
             }
 
+            if (SymbolEqualityComparer.Default.Equals(paramsParameter.Type.OriginalDefinition, context.RoslynTypeSystem.SystemCollectionsGenericIEnumerableOfT))
+            {
+                context.EmitError($"Cecilifier does not support type {paramsParameter.Type} as a 'params' parameter ({paramsParameter.Name}). You may change {paramsParameter.Name}' to 'ICollection<T>'", paramsParameter.DeclaringSyntaxReferences.First().GetSyntax());
+                return null;
+            }
+            
             return paramsParameter.Type switch
             {
                 IArrayTypeSymbol => new ArrayExpandedParamsArgumentHandler(context, paramsParameter, argumentList, ilVar),

--- a/Cecilifier.Core/Extensions/ISymbolExtensions.cs
+++ b/Cecilifier.Core/Extensions/ISymbolExtensions.cs
@@ -98,9 +98,11 @@ namespace Cecilifier.Core.Extensions
         public static bool IsByRef(this ISymbol symbol) =>
             symbol switch
             {
-                IParameterSymbol parameterSymbol when parameterSymbol.RefKind != RefKind.None => true,
+                IParameterSymbol { RefKind: RefKind.In or RefKind.Out or RefKind.RefReadOnlyParameter or RefKind.Ref } => true,
                 IPropertySymbol { ReturnsByRef: true } => true,
+                IPropertySymbol { ReturnsByRefReadonly: true } => true,
                 IMethodSymbol { ReturnsByRef: true } => true,
+                IMethodSymbol { ReturnsByRefReadonly: true } => true,
                 ILocalSymbol { IsRef: true } => true,
                 IFieldSymbol { RefKind: not RefKind.None } => true,
 
@@ -287,6 +289,8 @@ namespace Cecilifier.Core.Extensions
             {
                 IArrayTypeSymbol => new ArrayExpandedParamsArgumentHandler(context, paramsParameter, argumentList, ilVar),
                 INamedTypeSymbol namedType when SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, context.RoslynTypeSystem.SystemSpan)  => new SpanExpandedParamsArgumentHandler(context, paramsParameter, argumentList, ilVar),
+                INamedTypeSymbol namedType when SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, context.RoslynTypeSystem.SystemReadOnlySpan.Value) => new ReadOnlySpanExpandedParamsArgumentHandler(context, paramsParameter, argumentList, ilVar),
+                INamedTypeSymbol namedType when SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, context.RoslynTypeSystem.SystemCollectionsGenericIEnumerableOfT)  => new ReadOnlySpanExpandedParamsArgumentHandler(context, paramsParameter, argumentList, ilVar),
                 _ => throw new NotImplementedException($"Type {paramsParameter.Type} is not supported.")
             };
             

--- a/Cecilifier.Core/Extensions/TypeExtensions.cs
+++ b/Cecilifier.Core/Extensions/TypeExtensions.cs
@@ -46,6 +46,7 @@ namespace Cecilifier.Core.Extensions
         public static ITypeSymbol ElementTypeSymbolOf(this ITypeSymbol type) => type switch
         {
             INamedTypeSymbol { IsGenericType: true, OriginalDefinition: { ContainingNamespace.Name: "System", Name: "Span" } } ns =>  ns.TypeArguments[0],
+            INamedTypeSymbol { IsGenericType: true, OriginalDefinition: { ContainingNamespace.Name: "System", Name: "ReadOnlySpan" } } ns =>  ns.TypeArguments[0],
             IPointerTypeSymbol ptr => ptr.PointedAtType,
             IArrayTypeSymbol array =>  array.ElementType,
             _ => type

--- a/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
+++ b/Cecilifier.Core/Misc/CecilDefinitionsFactory.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -14,7 +16,7 @@ using Mono.Cecil.Cil;
 
 namespace Cecilifier.Core.Misc
 {
-    internal record ParameterSpec(string Name, string ElementType, RefKind RefKind, string Attributes, string DefaultValue = null, Func<IVisitorContext, string, string> ElementTypeResolver = null)
+    internal record ParameterSpec(string Name, string ElementType, RefKind RefKind, string Attributes, string? DefaultValue = null, Func<IVisitorContext, string, string>? ElementTypeResolver = null)
     {
         public string RegistrationTypeName { get; init; }
     }
@@ -100,7 +102,7 @@ namespace Cecilifier.Core.Misc
             return exps;
         }
 
-        internal static string Constructor(IVisitorContext context, string ctorLocalVar, string typeName, bool isStatic, string methodAccessibility, string[] paramTypes, string methodDefinitionPropertyValues = null)
+        internal static string Constructor(IVisitorContext context, string ctorLocalVar, string typeName, bool isStatic, string methodAccessibility, string[] paramTypes, string? methodDefinitionPropertyValues = null)
         {
             var ctorName = Utils.ConstructorMethodName(isStatic);
             context.DefinitionVariables.RegisterMethod(typeName, ctorName, paramTypes, 0, ctorLocalVar);
@@ -191,7 +193,7 @@ namespace Cecilifier.Core.Misc
             DefinitionVariable outerTypeVariable,
             bool isStructWithNoFields,
             IEnumerable<ITypeSymbol> interfaces,
-            IEnumerable<TypeParameterSyntax> ownTypeParameters,
+            IEnumerable<TypeParameterSyntax>? ownTypeParameters,
             IEnumerable<TypeParameterSyntax> outerTypeParameters,
             params string[] properties)
         {
@@ -213,7 +215,7 @@ namespace Cecilifier.Core.Misc
             }
 
             // add type parameters from outer types. 
-            var outerTypeParametersArray = outerTypeParameters?.ToArray() ?? [];
+            var outerTypeParametersArray = outerTypeParameters.ToArray();
             ProcessGenericTypeParameters(typeVar, context, outerTypeParametersArray.Concat(typeParamList).ToArray(), exps);
             
             foreach (var itf in interfaces)
@@ -262,7 +264,7 @@ namespace Cecilifier.Core.Misc
             return string.Empty;
         }
 
-        public static IEnumerable<string> Field(IVisitorContext context, string declaringTypeName, string declaringTypeVar, string fieldVar, string name, string fieldType, string fieldAttributes, object constantValue = null)
+        public static IEnumerable<string> Field(IVisitorContext context, string declaringTypeName, string declaringTypeVar, string fieldVar, string name, string fieldType, string fieldAttributes, object? constantValue = null)
         {
             context.DefinitionVariables.RegisterNonMethod(declaringTypeName, name, VariableMemberKind.Field, fieldVar);
             var fieldExp = $"var {fieldVar} = new FieldDefinition(\"{name}\", {fieldAttributes}, {fieldType})";
@@ -273,7 +275,7 @@ namespace Cecilifier.Core.Misc
             ];
         }
 
-        public static string ParameterDoesNotHandleParamsKeywordOrDefaultValue(string name, RefKind byRef, string resolvedType, string paramAttributes = null)
+        public static string ParameterDoesNotHandleParamsKeywordOrDefaultValue(string name, RefKind byRef, string resolvedType, string? paramAttributes = null)
         {
             paramAttributes ??= Constants.ParameterAttributes.None;
             if (RefKind.None != byRef)
@@ -284,7 +286,7 @@ namespace Cecilifier.Core.Misc
             return $"new ParameterDefinition(\"{name}\", {paramAttributes}, {resolvedType})";
         }
 
-        public static IEnumerable<string> Parameter(string name, RefKind byRef, string paramsAttributeTypeName, string methodVar, string paramVar, string resolvedType, string paramAttributes, (string Value, bool Present) defaultParameterValue)
+        public static IEnumerable<string> Parameter(string name, RefKind byRef, string? paramsAttributeTypeName, string methodVar, string paramVar, string resolvedType, string paramAttributes, (string Value, bool Present) defaultParameterValue)
         {
             var exps = new List<string>();
 
@@ -358,11 +360,11 @@ namespace Cecilifier.Core.Misc
 
             void ProcessAttributeNamedArguments(SymbolKind symbolKind, string container)
             {
-                var attrMemberNames = attrType.Type.GetMembers().Where(m => m.Kind == symbolKind).Select(m => m.Name).ToHashSet();
-                foreach (var namedArgument in attribute.ArgumentList.Arguments.Except(attributeArguments).Where(arg => attrMemberNames.Contains(arg.NameEquals.Name.Identifier.Text)))
+                var attrMemberNames = attrType.Type!.GetMembers().Where(m => m.Kind == symbolKind).Select(m => m.Name).ToHashSet();
+                foreach (var namedArgument in attribute.ArgumentList.Arguments.Except(attributeArguments).Where(arg => attrMemberNames.Contains(arg.NameEquals!.Name.Identifier.Text)))
                 {
                     var argType = context.GetTypeInfo(namedArgument.Expression);
-                    exps.Add($"{customAttrVar}.{container}.Add(new CustomAttributeNamedArgument(\"{namedArgument.NameEquals.Name.Identifier.ValueText}\", {CustomAttributeArgument(argType, namedArgument)}));");
+                    exps.Add($"{customAttrVar}.{container}.Add(new CustomAttributeNamedArgument(\"{namedArgument.NameEquals!.Name.Identifier.ValueText}\", {CustomAttributeArgument(argType, namedArgument)}));");
                 }
             }
         }
@@ -392,7 +394,7 @@ namespace Cecilifier.Core.Misc
             var genericTypeParamEntries = ArrayPool<(string genParamDefVar, ITypeParameterSymbol typeParameterSymbol)>.Shared.Rent(typeParamList.Count);
             for (int i = 0; i < typeParamList.Count; i++)
             {
-                var symbol = context.SemanticModel.GetDeclaredSymbol(typeParamList[i]);
+                var symbol = context.SemanticModel.GetDeclaredSymbol(typeParamList[i]).EnsureNotNull();
                 var genericParamName = typeParamList[i].Identifier.Text;
 
                 var genParamDefVar = context.Naming.GenericParameterDeclaration(typeParamList[i]);
@@ -535,6 +537,69 @@ namespace Cecilifier.Core.Misc
                 context.WriteComment($"*****************************************************************");
                 context.WriteComment($"WARNING: Converting static method ({staticDelegateCacheContext.Method.FullyQualifiedName()}) to delegate in a type other than the one defining it may generate incorrect code. Access type: {currentType.MemberName}, Method type: {staticDelegateCacheContext.Method.ContainingType.Name}");
                 context.WriteComment($"*****************************************************************");
+            }
+        }
+
+        public static class Collections
+        {
+            /// <summary>
+            /// When passing some types of params parameters Cecilifier needs to generate code to instantiate a List{T} and populate its values.
+            /// In addition to that this method introduces a local variable of type <see cref="System.Span{T}"/> and initializes it with a
+            /// reference to the instantiated <see cref="System.Collections.Generic.List{T}"/>.
+            ///
+            /// Callers can use that variable to initialize the list in a performant way.  
+            /// </summary>
+            /// <param name="context"></param>
+            /// <param name="listOfTTypeSymbol"><see cref="ITypeSymbol"/> for the List{T}.</param>
+            /// <param name="elementCount">Number of elements to be stored.</param>
+            public static (DefinitionVariable, string) InstantiateListToStoreElements(IVisitorContext context, string ilVar, INamedTypeSymbol listOfTTypeSymbol, int elementCount)
+            {
+                var resolvedListTypeArgument = context.TypeResolver.Resolve(listOfTTypeSymbol.TypeArguments[0]);
+
+                context.WriteNewLine();
+                context.WriteComment("Instantiates a List<T> passing the # of elements to its ctor.");
+                context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, elementCount);
+                context.EmitCilInstruction(ilVar, OpCodes.Newobj, listOfTTypeSymbol.Constructors.First(ctor => ctor.Parameters.Length == 1).MethodResolverExpression(context));
+
+                // Pushes an extra copy of the reference to the list instance into the stack
+                // to avoid introducing a local variable. This will be left at the top of the stack
+                // when the initialization code finishes.
+                context.EmitCilInstruction(ilVar, OpCodes.Dup);
+
+                // Calls 'CollectionsMarshal.SetCount(list, num)' on the list.
+                var collectionMarshalTypeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.Runtime.InteropServices.CollectionsMarshal).FullName!).EnsureNotNull();
+                var setCountMethod = collectionMarshalTypeSymbol.GetMembers("SetCount").OfType<IMethodSymbol>().Single().MethodResolverExpression(context).MakeGenericInstanceMethod(context, "SetCount", [ resolvedListTypeArgument ]); 
+                
+                context.EmitCilInstruction(ilVar, OpCodes.Dup);
+                context.EmitCilInstruction(ilVar, OpCodes.Ldc_I4, elementCount);
+                context.EmitCilInstruction(ilVar, OpCodes.Call, setCountMethod);
+                
+                context.WriteNewLine();
+                context.WriteComment("Add a Span<T> local variable and initialize it with `CollectionsMarshal.AsSpan(list)`");
+                var spanToList = context.AddLocalVariableToCurrentMethod(
+                    "listSpan", 
+                    context.TypeResolver.Resolve(context.RoslynTypeSystem.SystemSpan).MakeGenericInstanceType(resolvedListTypeArgument));
+
+                context.EmitCilInstruction(ilVar, 
+                    OpCodes.Call, 
+                    collectionMarshalTypeSymbol.GetMembers("AsSpan").OfType<IMethodSymbol>().Single().MethodResolverExpression(context).MakeGenericInstanceMethod(context, "AsSpan", [ resolvedListTypeArgument ]));
+                context.EmitCilInstruction(ilVar, OpCodes.Stloc, spanToList.VariableName);
+                
+                return (spanToList, resolvedListTypeArgument);
+            }
+            
+            public static string GetSpanIndexerGetter(IVisitorContext context, string typeArgument)
+            {
+                var methodVar = context.Naming.SyntheticVariable("getItem", ElementKind.Method);
+                var declaringType = context.TypeResolver.Resolve(context.RoslynTypeSystem.SystemSpan).MakeGenericInstanceType(typeArgument);
+                context.WriteCecilExpression($$"""var {{methodVar}} = new MethodReference("get_Item", {{context.TypeResolver.Bcl.System.Void}}, {{declaringType}}) { HasThis = true, ExplicitThis = false };""");
+                context.WriteNewLine();
+                context.WriteCecilExpression($"{methodVar}.Parameters.Add(new ParameterDefinition({context.TypeResolver.Bcl.System.Int32}));");
+                context.WriteNewLine();
+                context.WriteCecilExpression($"""{methodVar}.ReturnType = ((GenericInstanceType) {methodVar}.DeclaringType).ElementType.GenericParameters[0].MakeByReferenceType();""");
+                context.WriteNewLine();
+
+                return methodVar;
             }
         }
     }

--- a/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
+++ b/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
@@ -21,6 +21,7 @@ public struct RoslynTypeSystem
         SystemRange = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Range).FullName!);
         SystemType = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Type).FullName!);
         SystemSpan = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Span<>).FullName!);
+        SystemReadOnlySpan = new Lazy<ITypeSymbol>(() => ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(ReadOnlySpan<>).FullName!));
         CallerArgumentExpressionAttribute = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(CallerArgumentExpressionAttribute).FullName!);
 
         SystemInt32 = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Int32);
@@ -52,6 +53,8 @@ public struct RoslynTypeSystem
     public ITypeSymbol SystemRange { get; }
     public ITypeSymbol SystemType { get; }
     public ITypeSymbol SystemSpan { get; }
+    
+    public Lazy<ITypeSymbol> SystemReadOnlySpan { get; }
     public ITypeSymbol SystemInt32 { get; }
     public ITypeSymbol SystemInt64 { get; }
     public ITypeSymbol SystemIntPtr { get; }

--- a/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
+++ b/Cecilifier.Core/TypeSystem/RoslynTypeSystem.cs
@@ -43,6 +43,8 @@ public struct RoslynTypeSystem
         SystemCollectionsGenericIEnumeratorOfT = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T);
         SystemCollectionsIEnumerable = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
         SystemCollectionsGenericIEnumerableOfT = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
+        SystemCollectionsGenericIListOfT = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IList_T);
+        SystemCollectionsGenericICollectionOfT = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_ICollection_T);
         SystemNullableOfT = ctx.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Nullable_T);
         SystemRuntimeCompilerServicesUnsafe = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Unsafe).FullName);
         SystemRuntimeInteropServicesMemoryMarshal = ctx.SemanticModel.Compilation.GetTypeByMetadataName(typeof(MemoryMarshal).FullName);
@@ -69,6 +71,7 @@ public struct RoslynTypeSystem
     public ITypeSymbol SystemCollectionsGenericIEnumeratorOfT { get; }
     public ITypeSymbol SystemCollectionsIEnumerable { get; }
     public ITypeSymbol SystemCollectionsGenericIEnumerableOfT { get; }
+    public ITypeSymbol SystemCollectionsGenericIListOfT { get; }
     public ITypeSymbol CallerArgumentExpressionAttribute { get; }
     public ITypeSymbol IsReadOnlyAttribute { get; }
     public ITypeSymbol IsByRefLikeAttribute { get; }
@@ -79,6 +82,7 @@ public struct RoslynTypeSystem
     public ITypeSymbol SystemNullableOfT { get; }
     public ITypeSymbol SystemRuntimeCompilerServicesUnsafe { get;  }
     public ITypeSymbol SystemRuntimeInteropServicesMemoryMarshal { get; }
+    public ITypeSymbol SystemCollectionsGenericICollectionOfT { get; }
 
     public readonly ITypeSymbol ForType<TType>() => _context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(TType).FullName!);
 

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Cecilifier.Core.Tests" />
     <ProjectReference Include="..\Cecilifier.TypeMapGenerator\Cecilifier.TypeMapGenerator.csproj" 
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />

--- a/Cecilifier.Runtime/Cecilifier.Runtime.csproj
+++ b/Cecilifier.Runtime/Cecilifier.Runtime.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>13</LangVersion>
-    <AssemblyVersion>2.21.0</AssemblyVersion>
+    <AssemblyVersion>2.22.0</AssemblyVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 

--- a/Cecilifier.Web/Startup.cs
+++ b/Cecilifier.Web/Startup.cs
@@ -284,8 +284,17 @@ namespace Cecilifier.Web
                     foreach (var source in files)
                     {
                         var entry = zipFile.CreateEntry(source.fileName, CompressionLevel.Optimal);
-                        using var entryWriter = new StreamWriter(entry.Open());
-                        entryWriter.Write(source.contents);
+                        if (source.contents.StartsWith("file-relative-path://"))
+                        {
+                            using var entryStream = entry.Open();
+                            var basePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                            entryStream.Write(File.ReadAllBytes(Path.Combine(basePath, source.contents.Substring("file-relative-path://".Length))));
+                        }
+                        else
+                        {
+                            using var entryWriter = new StreamWriter(entry.Open());
+                            entryWriter.Write(source.contents);
+                        }
                     }
                 }
                 return zipStream.ToArray();

--- a/Cecilifier.Web/wwwroot/js/cecilifier.js
+++ b/Cecilifier.Web/wwwroot/js/cecilifier.js
@@ -169,15 +169,12 @@ function configureKeyboardShortcuts() {
     });
 
     csharpCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyMod.Alt + monaco.KeyCode.KeyL, function() {
-        showListOfLocallyStoredSnippets();
+        showListOfLocallyStoredSnippets(csharpCode);
     });
 
     // Cecilified code
     cecilifiedCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyCode.BracketLeft , decreaseFocusedEditorFontSize);
     cecilifiedCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyCode.BracketRight , increaseFocusedEditorFontSize);
-    cecilifiedCode.addCommand(monaco.KeyMod.CtrlCmd + monaco.KeyMod.Alt + monaco.KeyCode.KeyL, function() {
-        showListOfLocallyStoredSnippets();
-    });
 }
 
 function configureCursorInformationVisibility(show) {

--- a/Cecilifier.Web/wwwroot/js/cecilifier.snippethandler.js
+++ b/Cecilifier.Web/wwwroot/js/cecilifier.snippethandler.js
@@ -81,23 +81,89 @@ function cecilifyFromSnippet(counter) {
     }
 }
 
-function showListOfLocallyStoredSnippets() {
+let savedSnippetSnack = null;
+function showListOfLocallyStoredSnippets(editor) {
     let snippetNames = [];
+    if (savedSnippetSnack !== null)
+    {
+        return;
+    }
+
     for(let i = 0; i < window.localStorage.length; i++) {
         let key = window.localStorage.key(i);
         if (key.startsWith(saved_snippet_prefix)) {
             let snippetName= key.substring(saved_snippet_prefix.length); 
-            snippetNames.push(`<div id="${snippetName}-to-remove" class="shortcut"><a href="#" title="Removes ${snippetName}." onclick="removeSnippet('${snippetName}');"><i class="fa-solid fa-trash-can"></i></a> <a href="${snippetName}" title="Loads ${snippetName}.">${snippetName}</a><br /></div>`);
+            snippetNames.push(
+                `<div id="${snippetName}-to-remove" 
+                        class="shortcut">
+                        <a href="${snippetName}" title="Loads ${snippetName} snippet into editor"><i class="fa-solid fa-upload"></i></a> 
+                        <a href="#" title="Removes ${snippetName} snippet." onclick="removeSnippet('${snippetName}');"><i class="fa-solid fa-trash-can"></i></a><a href="${snippetName}" title="Loads ${snippetName}snippet into editor"> ${snippetName}</a><br /></div>`);
         }
     }
     
-    SnackBar({
+    savedSnippetSnack = SnackBar({
         message: `<b>Saved snippets</b><br /><br/>${snippetNames.reduce( (acc, current) => `${acc}${current}`)}`,
         dismissible: true,
         status: "Info",
         timeout: false,
         icon: "!"
     });
+
+    const closeSavedSnippetListAction = setupShortcutToCloseSaveSnippetList(editor);
+    setupObserverToResetSavedSnippetListSnackUponClosing(closeSavedSnippetListAction);
+}
+
+function setupShortcutToCloseSaveSnippetList(editor) {
+
+    const action = editor.addAction({
+        id: "close-saved-snippet-list",
+
+        label: "Close saved snippet list",
+
+        keybindings: [monaco.KeyCode.KeyX],
+
+        // A precondition for this action.
+        precondition: null,
+
+        // A rule to evaluate on top of the precondition in order to dispatch the keybindings.
+        keybindingContext: null,
+
+        contextMenuGroupId: "navigation",
+
+        contextMenuOrder: 1.5,
+
+        run: function (ed) {
+            const temp = savedSnippetSnack;
+            savedSnippetSnack = null;
+            temp.Close();
+
+        },
+    });
+
+    return action;
+}
+
+function setupObserverToResetSavedSnippetListSnackUponClosing(closeSavedSnippetListAction) {
+    // To avoid showing multiple lists ideally we should be able to subscribe to a `closing` event on the snack with the list of saved snippets
+    // and set `savedSnippetSnack` to null; unfortunately there's no such event whence we rely on implementation details of SnackBar and 
+    // watch for changes in the style attribute of a element of the 'js-snackbar__wrapper' which SnackBar updates when the snack is closed.
+    const snackMessage = Array.from(document.getElementsByClassName("js-snackbar__wrapper")).filter(element => element.innerHTML.indexOf("Saved snippets") !== -1).at(0);
+
+    const config = { attributes: true, childList: false, characterData: false };
+
+    const callback = mutations => {
+        mutations.forEach(mutation => {
+            if (mutation.attributeName === 'style') {
+                savedSnippetSnack = null;
+                closeSavedSnippetListAction.dispose();
+            }
+            if (mutation.attributeName === 'style')
+                savedSnippetSnack = null;
+        });
+    };
+
+    const observer = new MutationObserver(callback);
+    observer.observe(snackMessage, config);
 }
 
 function removeSnippet(snippetName) {


### PR DESCRIPTION

8de8e928 fixes handling of ref generic fields (#340)
d1c703e8 fixes code generated when referening members of generic types (#334)
4784dbc5 fixes invalid NuGet package when downloading zipped project
70d59258 improves how list of saved snippets are shown
e2fc5a7f reports declaring 'params' parameters of Nullable<T> (and a couple others) as not supported (#336)
a617ead4 Implements support for declaring/passing 'params'  parameters of types IList<T>, ICollection<T> (#301)
4af29e63 reports IEnumerable<T> 'params' as unsupported by cecilifier (#301)
58cb4aac implements declaring/passing 'params' of ReadOnlySpan<T> (#301)
1d92caed fixes handling of inner types in PrivateCorlibFixerMixin
2986fa22 code cleanup: renamed test
36a3192d implements declaring/passing 'params' of Span<T> (#301)
04da8e0e adds handling for 'params' parameters (arrays only) (#335)
390930ef adds tests for method declarations with 'params' parameters
