### PR TITLE
May 2026 Update

### DIFF
--- a/Cecilifier.ApiDriver.MonoCecil/MonoCecilContext.cs
+++ b/Cecilifier.ApiDriver.MonoCecil/MonoCecilContext.cs
@@ -27,6 +27,8 @@ public class MonoCecilContext : CecilifierContextBase, IVisitorContext
         return ((string) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")).Split(Path.PathSeparator);
     }
 
+    public static string[] GetPreprocessorSymbols() => ["API_DRIVER_MONO_CECIL"];
+
     public override void OnFinishedTypeDeclaration(INamedTypeSymbol _) { } // Nothing to do here for Mono.Cecil
 
     public override DefinitionVariable GetMethodVariable(IMethodSymbol method) => DefinitionVariables.GetMethodVariable(method.AsMethodDefinitionVariable());

--- a/Cecilifier.ApiDriver.MonoCecil/MonoCecilDefinitionsFactory.cs
+++ b/Cecilifier.ApiDriver.MonoCecil/MonoCecilDefinitionsFactory.cs
@@ -175,6 +175,14 @@ internal class MonoCecilDefinitionsFactory : DefinitionsFactoryBase, IApiDriverD
         return exps;
     }
 
+    public IEnumerable<string> FieldReference(IVisitorContext context, string fieldReferenceVariable, string fieldName, ResolvedType fieldType, in ResolvedType declaringType)
+    {
+        return
+        [
+            $"""var {fieldReferenceVariable} = new FieldReference("{fieldName}", {fieldType}, {declaringType.Expression});"""
+        ];
+    }
+
     public IEnumerable<string> MethodBody(IVisitorContext context, string methodName, IlContext ilContext, ResolvedType[] localVariableTypes, InstructionRepresentation[] instructions)
     {
         var tagToInstructionDefMapping = new Dictionary<string, string>();

--- a/Cecilifier.ApiDriver.MonoCecil/TypeSystem/MonoCecilTypeResolver.cs
+++ b/Cecilifier.ApiDriver.MonoCecil/TypeSystem/MonoCecilTypeResolver.cs
@@ -39,7 +39,7 @@ public class MonoCecilTypeResolver(MonoCecilContext context) : TypeResolverBase<
         return CecilDefinitionsFactory.FunctionPointerType(this, functionPointer);
     }
 
-    protected override ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext)
+    public override ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext)
     {
         Buffer256<ITypeSymbol> g = new();
         var resolutionContextTypeParameterProviderVar = resolutionContext.TypeParameterProviderVar;

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/SystemReflectionMetadataContext.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/SystemReflectionMetadataContext.cs
@@ -56,6 +56,7 @@ public class SystemReflectionMetadataContext : CecilifierContextBase, IVisitorCo
             throw new Exception("DOTNET_ROOT environment variable is not set");
         }       
         return Directory.GetFiles($"{dotnetRoot}/packs/Microsoft.NETCore.App.Ref/{Environment.Version}/ref/net{Environment.Version.Major}.{Environment.Version.Minor}", "*.dll");
-        
     }
+    
+    public static string[] GetPreprocessorSymbols() => ["API_DRIVER_SYSTEM_REFLECTION_METADATA"];
 }

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/SystemReflectionMetadataDefinitionsFactory.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/SystemReflectionMetadataDefinitionsFactory.cs
@@ -376,6 +376,20 @@ internal class SystemReflectionMetadataDefinitionsFactory : DefinitionsFactoryBa
         return span.Slice(0, expCount).ToArray();
     }
 
+    public IEnumerable<string> FieldReference(IVisitorContext context, string fieldReferenceVariable, string fieldName, ResolvedType fieldType, in ResolvedType declaringType)
+    {
+        Buffer16<string> exps = new();
+        var count = -1;
+
+        var tempSignatureVarName = context.Naming.SyntheticVariable($"{fieldName.ToValidIdentifier()}Sig", ElementKind.MemberReference);
+        exps[++count] = $"var {tempSignatureVarName} = new BlobEncoder(new BlobBuilder()).Field();";
+        exps[++count] = $"{tempSignatureVarName}.{fieldType.Expression};";
+        exps[++count] = $"""var {fieldReferenceVariable} = metadata.AddMemberReference({declaringType.Expression}, metadata.GetOrAddString("{fieldName}"), metadata.GetOrAddBlob({tempSignatureVarName}.Builder));""";
+        Span<string> span = exps;
+        
+        return span.Slice(0, count + 1).ToArray();
+    }
+
     public IEnumerable<string> MethodBody(IVisitorContext context, string methodName, IlContext ilContext, ResolvedType[] localVariableTypes, InstructionRepresentation[] instructions) => [];
 
     public DefinitionVariable LocalVariable(IVisitorContext context, string variableName, string methodDefinitionVariableName, ResolvedType resolvedVarType)

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataMemberResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataMemberResolver.cs
@@ -36,7 +36,7 @@ public class SystemReflectionMetadataMemberResolver(SystemReflectionMetadataCont
                                    {
                                        {{
                                            string.Join('\n',
-                                               method.Parameters.Select(p => $"""
+                                               method.OriginalDefinition.Parameters.Select(p => $"""
                                                                                   parameters
                                                                                           .AddParameter()
                                                                                           .{context.TypedTypeResolver.ResolveAny(p.Type, new TypeResolutionContext(ResolveTargetKind.Parameter, p.Type.IsValueType ? TypeResolutionOptions.IsValueType : TypeResolutionOptions.None))};

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -104,6 +104,12 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
     public override ResolvedType ResolveLocalVariableType(ITypeSymbol type, in TypeResolutionContext context)
     {
         var resolved = base.ResolveLocalVariableType(type, in context);
+
+        if (resolved && context.TargetKind == ResolveTargetKind.Instruction)
+        {
+            return new ResolvedType($"MetadataTokens.GetToken({resolved})");
+        }
+        
         if (resolved && context.TargetKind != ResolveTargetKind.TypeReference)
         {
             var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument 

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -109,7 +109,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
             return new ResolvedType($"MetadataTokens.GetToken({resolved})");
         }
         
-        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && ((context.TargetKind != ResolveTargetKind.Field && context.TargetKind != ResolveTargetKind.ReturnType) || type is not INamedTypeSymbol { IsGenericType: true }))
+        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && ((context.TargetKind != ResolveTargetKind.Field && context.TargetKind != ResolveTargetKind.ReturnType && context.TargetKind != ResolveTargetKind.LocalVariable) || type is not INamedTypeSymbol { IsGenericType: true }))
         {
             var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument || type.TypeKind == TypeKind.TypeParameter
                 ? $"GenericTypeParameter({resolved.Expression})" 

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -31,7 +31,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
                            """);
         _context.WriteNewLine();
 
-        if (resolutionContext.TargetKind is ResolveTargetKind.TypeReference or ResolveTargetKind.ReturnType)
+        if (resolutionContext.TargetKind is ResolveTargetKind.TypeReference || type is INamedTypeSymbol { IsGenericType: true })
             return memberRefVarName;
         
         return ApplySpecificSyntax(memberRefVarName, in resolutionContext);
@@ -109,7 +109,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
             return new ResolvedType($"MetadataTokens.GetToken({resolved})");
         }
         
-        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && (context.TargetKind != ResolveTargetKind.ReturnType || type is not INamedTypeSymbol { IsGenericType: true }))
+        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && ((context.TargetKind != ResolveTargetKind.Field && context.TargetKind != ResolveTargetKind.ReturnType) || type is not INamedTypeSymbol { IsGenericType: true }))
         {
             var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument 
                 ? $"GenericTypeParameter({resolved.Expression})" 
@@ -137,11 +137,10 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         if (typeArguments.Length == 0)
             return typeReference;
 
-        if (resolutionContext.TargetKind == ResolveTargetKind.Field || resolutionContext.TargetKind == ResolveTargetKind.Parameter || resolutionContext.TargetKind == ResolveTargetKind.ReturnType)
+        if (resolutionContext.TargetKind is ResolveTargetKind.Field or ResolveTargetKind.Parameter or ResolveTargetKind.ReturnType)
         {
             var resolved = MakeGenericInstanceTypeForFieldDeclaration(typeReference, genericTypeSymbol, typeArguments);
-            
-            if (resolved && resolutionContext.TargetKind == ResolveTargetKind.ReturnType)
+            if (resolved && resolutionContext.TargetKind is ResolveTargetKind.ReturnType or ResolveTargetKind.Field)
             {
                 return ResolvedType.FromDetails(
                     new ResolvedTypeDetails()
@@ -233,7 +232,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
     private ResolvedType MakeGenericInstanceTypeForFieldDeclaration(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, ReadOnlySpan<ITypeSymbol> typeArguments)
     {
         var ret = $$"""
-                    WithSignatureTypeEncoder(typeSignatureEncoder => 
+                    WithSignatureTypeEncoder(typeSignatureEncoder =>
                     {
                         var gi = typeSignatureEncoder.GenericInstantiation({{typeReference.Expression}}, {{typeArguments.Length}}, isValueType: {{genericTypeSymbol.IsValueType.ToKeyword()}});
                         {{

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -124,7 +124,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         return resolved;
     }
 
-    protected override ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext)
+    public override ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext)
     {
         Buffer256<ITypeSymbol> typeArgumentsBuffer = new();
         ReadOnlySpan<ITypeSymbol> typeArguments = CollectTypeArguments(genericTypeSymbol, ref typeArgumentsBuffer);

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -137,10 +137,10 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         if (typeArguments.Length == 0)
             return typeReference;
 
-        if (resolutionContext.TargetKind is ResolveTargetKind.Field or ResolveTargetKind.Parameter or ResolveTargetKind.ReturnType)
+        if (resolutionContext.TargetKind is ResolveTargetKind.Field or ResolveTargetKind.Parameter or ResolveTargetKind.ReturnType or ResolveTargetKind.LocalVariable)
         {
             var resolved = MakeGenericInstanceTypeForFieldDeclaration(typeReference, genericTypeSymbol, typeArguments);
-            if (resolved && resolutionContext.TargetKind is ResolveTargetKind.ReturnType or ResolveTargetKind.Field)
+            if (resolved && resolutionContext.TargetKind is ResolveTargetKind.ReturnType or ResolveTargetKind.Field or  ResolveTargetKind.LocalVariable)
             {
                 return ResolvedType.FromDetails(
                     new ResolvedTypeDetails()

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -110,7 +110,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
                 ? $"GenericTypeParameter({resolved.Expression})" 
                 : $"Type({resolved.Expression}, isValueType: {context.Options.HasFlag(TypeResolutionOptions.IsValueType).ToKeyword()})";
 
-            if ((context.TargetKind == ResolveTargetKind.Field || context.TargetKind == ResolveTargetKind.Parameter) && type is INamedTypeSymbol { IsGenericType: true })
+            if ((context.TargetKind == ResolveTargetKind.Field || context.TargetKind == ResolveTargetKind.Parameter || context.TargetKind == ResolveTargetKind.ReturnType) && type is INamedTypeSymbol { IsGenericType: true })
             {
                 methodBuilder = resolved.Expression;
             }
@@ -132,7 +132,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         if (typeArguments.Length == 0)
             return typeReference;
 
-        if (resolutionContext.TargetKind == ResolveTargetKind.Field || resolutionContext.TargetKind == ResolveTargetKind.Parameter)
+        if (resolutionContext.TargetKind == ResolveTargetKind.Field || resolutionContext.TargetKind == ResolveTargetKind.Parameter || resolutionContext.TargetKind == ResolveTargetKind.ReturnType)
         {
             return MakeGenericInstanceTypeForFieldDeclaration(typeReference, genericTypeSymbol, typeArguments);
         }

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -12,7 +12,6 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
 {
     public override ResolvedType Resolve(ITypeSymbol type, in TypeResolutionContext resolutionContext)
     {
-        
         var memberRefVar = _context.DefinitionVariables.GetVariable(type.ToDisplayString(), VariableMemberKind.Type, type.ContainingSymbol.ToDisplayString());
         var memberRefVarName = memberRefVar.IsValid 
                                         ? memberRefVar.VariableName

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -111,7 +111,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         
         if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && ((context.TargetKind != ResolveTargetKind.Field && context.TargetKind != ResolveTargetKind.ReturnType) || type is not INamedTypeSymbol { IsGenericType: true }))
         {
-            var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument 
+            var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument || type.TypeKind == TypeKind.TypeParameter
                 ? $"GenericTypeParameter({resolved.Expression})" 
                 : $"Type({resolved.Expression}, isValueType: {context.Options.HasFlag(TypeResolutionOptions.IsValueType).ToKeyword()})";
 

--- a/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
+++ b/Cecilifier.ApiDriver.SystemReflectionMetadata/TypeSystem/SystemReflectionMetadataTypeResolver.cs
@@ -31,7 +31,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
                            """);
         _context.WriteNewLine();
 
-        if (resolutionContext.TargetKind == ResolveTargetKind.TypeReference)
+        if (resolutionContext.TargetKind is ResolveTargetKind.TypeReference or ResolveTargetKind.ReturnType)
             return memberRefVarName;
         
         return ApplySpecificSyntax(memberRefVarName, in resolutionContext);
@@ -109,13 +109,13 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
             return new ResolvedType($"MetadataTokens.GetToken({resolved})");
         }
         
-        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference)
+        if (resolved && context.TargetKind != ResolveTargetKind.TypeReference && (context.TargetKind != ResolveTargetKind.ReturnType || type is not INamedTypeSymbol { IsGenericType: true }))
         {
             var methodBuilder = context.TargetKind == ResolveTargetKind.GenericTypeArgument 
                 ? $"GenericTypeParameter({resolved.Expression})" 
                 : $"Type({resolved.Expression}, isValueType: {context.Options.HasFlag(TypeResolutionOptions.IsValueType).ToKeyword()})";
 
-            if ((context.TargetKind == ResolveTargetKind.Field || context.TargetKind == ResolveTargetKind.Parameter || context.TargetKind == ResolveTargetKind.ReturnType) && type is INamedTypeSymbol { IsGenericType: true })
+            if ((context.TargetKind is ResolveTargetKind.Field or ResolveTargetKind.Parameter) && type is INamedTypeSymbol { IsGenericType: true })
             {
                 methodBuilder = resolved.Expression;
             }
@@ -139,7 +139,16 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
 
         if (resolutionContext.TargetKind == ResolveTargetKind.Field || resolutionContext.TargetKind == ResolveTargetKind.Parameter || resolutionContext.TargetKind == ResolveTargetKind.ReturnType)
         {
-            return MakeGenericInstanceTypeForFieldDeclaration(typeReference, genericTypeSymbol, typeArguments);
+            var resolved = MakeGenericInstanceTypeForFieldDeclaration(typeReference, genericTypeSymbol, typeArguments);
+            
+            if (resolved && resolutionContext.TargetKind == ResolveTargetKind.ReturnType)
+            {
+                return ResolvedType.FromDetails(
+                    new ResolvedTypeDetails()
+                        .WithTypeEncoder(TypeEncoderFor(in resolutionContext))
+                        .WithMethodBuilder(resolved.Expression));
+            }
+            return resolved;
         }
         
         var genericInstanceTypeVar = context.Naming.SyntheticVariable($"{genericTypeSymbol.ToValidVariableName()}Instantiation", ElementKind.GenericInstance);
@@ -220,6 +229,7 @@ public class SystemReflectionMetadataTypeResolver(SystemReflectionMetadataContex
         };
     }
     
+    //TODO: Method name is misleading. It is being also used for parameters/return types. What is the common thing about those
     private ResolvedType MakeGenericInstanceTypeForFieldDeclaration(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, ReadOnlySpan<ITypeSymbol> typeArguments)
     {
         var ret = $$"""

--- a/Cecilifier.Common.props
+++ b/Cecilifier.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>13</LangVersion>
-    <AssemblyVersion>2.26.0</AssemblyVersion>
+    <AssemblyVersion>2.27.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/Cecilifier.CommonPackages.props
+++ b/Cecilifier.CommonPackages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" /> 
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" /> 
     <PackageReference Include="Mono.Cecil"><Version>0.11.6</Version></PackageReference>
   </ItemGroup>
 </Project>

--- a/Cecilifier.CommonPackages.props
+++ b/Cecilifier.CommonPackages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" /> 
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" /> 
     <PackageReference Include="Mono.Cecil"><Version>0.11.6</Version></PackageReference>
   </ItemGroup>
 </Project>

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ILVerification" Version="9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />

--- a/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
+++ b/Cecilifier.Core.Tests/Cecilifier.Core.Tests.csproj
@@ -13,16 +13,16 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ILVerification" Version="9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cecilifier.ApiDriver.MonoCecil\Cecilifier.ApiDriver.MonoCecil.csproj" />

--- a/Cecilifier.Core.Tests/Framework/AssemblyDiff/AssemblyComparer.cs
+++ b/Cecilifier.Core.Tests/Framework/AssemblyDiff/AssemblyComparer.cs
@@ -491,7 +491,7 @@ namespace Cecilifier.Core.Tests.Framework.AssemblyDiff
             }
             else if (scopesToIgnore.Contains(frInstruction.DeclaringType.Scope) || scopesToIgnore.Contains(frCurrent.DeclaringType.Scope))
             {
-                validationResult = frInstruction.FieldType.FullName == frCurrent.FieldType.FullName;
+                validationResult = ValidateTypeReference(frInstruction.FieldType, frCurrent.FieldType);
             }
             else
             {
@@ -499,6 +499,38 @@ namespace Cecilifier.Core.Tests.Framework.AssemblyDiff
                                    frInstruction.DeclaringType.Scope.Name == "System.Private.CoreLib" 
                                             && (frCurrent.DeclaringType.Scope.Name == "System.Runtime" || frCurrent.DeclaringType.Scope.Name == "mscorlib"); 
             }
+            return true;
+        }
+        
+        private static bool TryValidateGenericParameter(TypeReference lhs, TypeReference rhs, out bool result)
+        {
+            result = false;
+            
+            var lhsGenericParameter = lhs as GenericParameter;
+            var rhsGenericParameter = rhs as GenericParameter;
+
+            if (lhsGenericParameter == null && rhsGenericParameter == null)
+            {
+                return false;
+            }
+
+            if (lhsGenericParameter != null ^ rhsGenericParameter != null)
+            {
+                result = false;
+                return true;
+            }
+            
+            // both are GenericParameter instances
+            if (lhsGenericParameter.Owner is TypeReference lhsOwner && rhsGenericParameter.Owner is TypeReference rhsOwner)
+            {
+                var lhsIndex = lhsOwner.GenericParameters.IndexOf(lhsGenericParameter);
+                var rhsIndex = rhsOwner.GenericParameters.IndexOf(rhsGenericParameter);
+                
+                result = lhsIndex == rhsIndex && ValidateTypeReference(lhsOwner, rhsOwner);
+                return true;
+            }
+            
+            result = true;
             return true;
         }
 
@@ -702,25 +734,50 @@ namespace Cecilifier.Core.Tests.Framework.AssemblyDiff
             return (ret, 1);
         }
 
-        private static bool ValidateTypeReference(TypeReference typeLhs, TypeReference typeRhs)
+        static bool ValidateTypeReference(TypeReference lhsType, TypeReference rhsType)
         {
-            var typeNameMatches = typeLhs.FullName == typeRhs.FullName;
-            if (!typeNameMatches)
-            {
+            if (TryValidateGenericParameter(lhsType, rhsType, out var validationResult))
+                return validationResult;
+            
+            if (lhsType.Namespace != rhsType.Namespace || lhsType.Name != rhsType.Name)
                 return false;
-            }
 
-            switch (typeLhs)
+            var lhsGenericInstance = lhsType as GenericInstanceType;
+            var rhsGenericInstance = rhsType as GenericInstanceType;
+            
+            if (lhsGenericInstance != null ^ rhsGenericInstance != null)
+                return false;
+
+            if (lhsGenericInstance == null) // both are not GenericInstanceType
             {
-                case ArrayType lhsAt:
-                    var rhsAt = typeRhs as ArrayType;
-                    return ValidateTypeReference(lhsAt.ElementType, rhsAt?.ElementType);
-
-                case GenericInstanceType _:
-                    var rhsGen = typeRhs as GenericInstanceType;
-                    return rhsGen != null;
+                var lhsArray = lhsType as ArrayType;
+                var rhsArray = rhsType as ArrayType;
+                if (lhsArray != null ^ rhsArray != null)
+                    return false;
+                
+                if (lhsArray != null)
+                    return ValidateTypeReference(lhsArray.ElementType, rhsArray.ElementType);
+                
+                return true;
             }
+            
+            return CompareGenericType(lhsGenericInstance, rhsGenericInstance);
+        }
 
+        private static bool CompareGenericType(GenericInstanceType lhs, GenericInstanceType rhs)
+        {
+            if (lhs.GenericArguments.Count != rhs.GenericArguments.Count)
+                return false;
+
+            for (int i = 0; i != lhs.GenericArguments.Count; i++)
+            {
+                var lhsTypeArgument = lhs.GenericArguments[i];
+                var rhsTypeArgument = rhs.GenericArguments[i];
+
+                if (!ValidateTypeReference(lhsTypeArgument, rhsTypeArgument))
+                    return false;
+            }
+            
             return true;
         }
 

--- a/Cecilifier.Core.Tests/Framework/Attributes/EnableForContextAttribute.cs
+++ b/Cecilifier.Core.Tests/Framework/Attributes/EnableForContextAttribute.cs
@@ -7,10 +7,10 @@ using NUnit.Framework.Internal;
 namespace Cecilifier.Core.Tests.Framework.Attributes;
 
 /// <summary>
-/// Configures which tests in test fixture are enabled/disabled for a specific Api Target (represented by the Target Api related context (See <typeparamref name="T" />) /> 
+/// Configures which tests in a test fixture are enabled/disabled for a specific Api Target (represented by the Target Api related context (See <typeparamref name="TContext" />) /> 
 /// </summary>
-/// <typeparam name="T">Context type associated with the target api./></typeparam>
-internal class EnableForContextAttribute<T> : FilterByContextBase<T>, IApplyToTest where T : IVisitorContext
+/// <typeparam name="TContext">Context type associated with the target api./></typeparam>
+internal class EnableForContextAttribute<TContext> : FilterByContextBase<TContext>, IApplyToTest where TContext : IVisitorContext
 {
     /// <summary>
     /// Allows specific tests to be enabled (listed in the attribute constructor argument) or disabled (not listed)

--- a/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
+++ b/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
@@ -35,8 +35,8 @@ public class CecilifierTestBase<TContext> where TContext : IVisitorContext
         var targetPath = Path.Combine(Path.GetDirectoryName(cecilifiedAssemblyPath), Path.GetFileNameWithoutExtension(cecilifiedAssemblyPath) + "-Expected");
 
         return buildType == BuildType.Exe
-            ? CompilationServices.CompileExe(targetPath, tbc, GetDotNetAssemblyReferences())
-            : CompilationServices.CompileDLL(targetPath, tbc, GetDotNetAssemblyReferences());
+            ? CompilationServices.CompileExe(targetPath, tbc, TContext.GetPreprocessorSymbols(), GetDotNetAssemblyReferences())
+            : CompilationServices.CompileDLL(targetPath, tbc, TContext.GetPreprocessorSymbols(), GetDotNetAssemblyReferences());
     }
 
     class AssemblyResolver : IResolver
@@ -238,7 +238,11 @@ public class CecilifierTestBase<TContext> where TContext : IVisitorContext
         stream.Position = 0;
         return Cecilifier.Process<TContext>(
             stream,
-            new CecilifierOptions { References = GetDotNetAssemblyReferences(), Naming = new DefaultNameStrategy() });
+            new CecilifierOptions
+            {
+                References = GetDotNetAssemblyReferences(), Naming = new DefaultNameStrategy(),
+                PreprocessorSymbols = TContext.GetPreprocessorSymbols()
+            });
     }
 
     private static string[] GetDotNetAssemblyReferences()

--- a/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
+++ b/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
@@ -7,7 +7,6 @@ using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
 using Cecilifier.Core.AST;
-using Cecilifier.Core.Misc;
 using Cecilifier.Core.Naming;
 using Cecilifier.Core.Tests.Framework.AssemblyDiff;
 using Cecilifier.Core.Tests.Framework.ILVerification;

--- a/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
+++ b/Cecilifier.Core.Tests/Framework/CecilifierTestBase.cs
@@ -150,7 +150,7 @@ public class CecilifierTestBase<TContext> where TContext : IVisitorContext
 
         var outputAssemblyPath = OutputAssemblyPath(Path.GetFileNameWithoutExtension(testBasePath));
         var testCompilationResult = new CecilifyResult(cecilifiedCode, cecilifierRunnerPath, outputAssemblyPath);
-        if (File.Exists(outputAssemblyPath))
+        if (File.Exists(outputAssemblyPath) && new FileInfo(outputAssemblyPath).Length > 0)
             return testCompilationResult;
             
         CopyFilesNextToGeneratedExecutable(cecilifierRunnerPath, refsToCopy);

--- a/Cecilifier.Core.Tests/Framework/CompilationServices.cs
+++ b/Cecilifier.Core.Tests/Framework/CompilationServices.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -11,17 +12,17 @@ namespace Cecilifier.Core.Tests.Framework
 {
     internal class CompilationServices
     {
-        public static string CompileDLL(string targetPath, string source, params string[] references)
+        public static string CompileDLL(string targetPath, string source, string[] preprocessorSymbols, params string[] references)
         {
-            return InternalCompile(targetPath, source, false, references);
+            return InternalCompile(targetPath, source, false, preprocessorSymbols, references);
         }
 
-        public static string CompileExe(string targetPath, string source, params string[] references)
+        public static string CompileExe(string targetPath, string source, string[] preprocessorSymbols, params string[] references)
         {
-            return InternalCompile(targetPath, source, true, references);
+            return InternalCompile(targetPath, source, true, preprocessorSymbols, references);
         }
 
-        private static string InternalCompile(string targetPath, string source, bool exe, string[] references)
+        private static string InternalCompile(string targetPath, string source, bool exe, string[] preprocessorSymbols, string[] references)
         {
             var targetFolder = Path.GetDirectoryName(targetPath);
             if (!Directory.Exists(targetFolder))
@@ -29,14 +30,15 @@ namespace Cecilifier.Core.Tests.Framework
                 Directory.CreateDirectory(targetFolder);
             }
             
-            var hash = BitConverter.ToString(SHA1.Create().ComputeHash(Encoding.ASCII.GetBytes(source))).Replace("-", "");
+            var hash = HashFor(source, preprocessorSymbols);
+
             var outputFilePath = $"{targetPath}-{hash}.{(exe ? "exe" : "dll")}";
             if (File.Exists(outputFilePath))
             {
                 return outputFilePath;
             }
 
-            var syntaxTree = SyntaxFactory.ParseSyntaxTree(SourceText.From(source), new CSharpParseOptions(LanguageVersion.Preview));
+            var syntaxTree = SyntaxFactory.ParseSyntaxTree(SourceText.From(source), new CSharpParseOptions(LanguageVersion.Preview, preprocessorSymbols: preprocessorSymbols));
 
             var compilationOptions = new CSharpCompilationOptions(
                 exe ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary,
@@ -62,7 +64,7 @@ namespace Cecilifier.Core.Tests.Framework
 
             return outputFilePath;
         }
-        
+
         public static string InternalCompile(string targetPath, string source, bool exe, string[] references, Func<string> computeCacheKey)
         {
             var targetFolder = Path.GetDirectoryName(targetPath);
@@ -102,6 +104,20 @@ namespace Cecilifier.Core.Tests.Framework
             compilation.Emit(outputAssembly, outputPdb);
 
             return outputFilePath;
+        }
+        
+        private static string HashFor(string source, string[] preprocessorSymbols)
+        {
+            using var hasher = SHA1.Create();
+            
+            hasher.Initialize();
+            var sourceBytes = Encoding.ASCII.GetBytes(source);
+            hasher.TransformBlock(Encoding.ASCII.GetBytes(source), 0, sourceBytes.Length, null, 0);
+            foreach (var preprocessorSymbol in preprocessorSymbols)
+                hasher.TransformBlock(Encoding.ASCII.GetBytes(preprocessorSymbol), 0, preprocessorSymbol.Length, null, 0);
+            hasher.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+
+            return BitConverter.ToString(hasher.Hash).Replace("-", "");
         }
     }
 }

--- a/Cecilifier.Core.Tests/Framework/CompilationServices.cs
+++ b/Cecilifier.Core.Tests/Framework/CompilationServices.cs
@@ -73,7 +73,7 @@ namespace Cecilifier.Core.Tests.Framework
 
             var hash = computeCacheKey();
             var outputFilePath = $"{targetPath}-{hash}.{(exe ? "exe" : "dll")}";
-            if (File.Exists(outputFilePath))
+            if (File.Exists(outputFilePath) && new FileInfo(outputFilePath).Length > 0)
             {
                 return outputFilePath;
             }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -24,8 +24,8 @@ class Test<T>
     Outer<T>.Inner<T> Method_T_T(Outer<T>.Inner<T> p) => p;
     
     //TODO: Enable when other scenarios are fixed. AOT it crashes the tests.
-    //object Cast(object o) => (Outer<T>.Inner<T>) o;
-    object TypeOf() => typeof(Outer<T>.Inner<T>);
+    object Cast(object o) => (Outer<T>.Inner<T>) o;
+    //object TypeOf() => typeof(Outer<T>.Inner<T>);
 
     void Instantiate_Int_String() { Method_Int_String(new Outer<int>.Inner<string>()); }    
     void Instantiate_T_T() { Method_T_T(new Outer<T>.Inner<T>()); }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -25,7 +25,7 @@ class Test<T>
     
     //TODO: Enable when other scenarios are fixed. AOT it crashes the tests.
     //object Cast(object o) => (Outer<T>.Inner<T>) o;
-    //object TypeOf() => typeof(Outer<T>.Inner<T>);
+    object TypeOf() => typeof(Outer<T>.Inner<T>);
 
     void Instantiate_Int_String() { Method_Int_String(new Outer<int>.Inner<string>()); }    
     void Instantiate_T_T() { Method_T_T(new Outer<T>.Inner<T>()); }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -11,15 +11,17 @@ class Test<T>
     Outer<T>.Inner<string> fT_String;
     Outer<T>.Inner<T> fT_T;
     
-/*
     // Test subject for properties
     Outer<int>.Inner<string> Prop_Int_String { get; set; }
+/*
     Outer<int>.Inner<T> Prop_Int_T { get; set; }
     Outer<T>.Inner<string> Prop_T_String { get; set; }
     Outer<T>.Inner<T> Prop_T_T { get; set; }
     
+*/    
     // Test subject for methods
     Outer<int>.Inner<string> Method_Int_String(Outer<int>.Inner<string> p) => p;
+/*    
     Outer<int>.Inner<T> Method_Int_T(Outer<int>.Inner<T> p) => p;
     Outer<T>.Inner<string> Method_T_String(Outer<T>.Inner<string> p) => p;
     Outer<T>.Inner<T> Method_T_T(Outer<T>.Inner<T> p) => p;

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -5,24 +5,30 @@ class Outer<O>
 
 class Test<T>
 {
+    // Test subject for fields
     Outer<int>.Inner<string> fInt_String;
     Outer<int>.Inner<T> fInt_T;
     Outer<T>.Inner<string> fT_String;
     Outer<T>.Inner<T> fT_T;
     
+/*
+    // Test subject for properties
     Outer<int>.Inner<string> Prop_Int_String { get; set; }
     Outer<int>.Inner<T> Prop_Int_T { get; set; }
     Outer<T>.Inner<string> Prop_T_String { get; set; }
     Outer<T>.Inner<T> Prop_T_T { get; set; }
     
+    // Test subject for methods
     Outer<int>.Inner<string> Method_Int_String(Outer<int>.Inner<string> p) => p;
     Outer<int>.Inner<T> Method_Int_T(Outer<int>.Inner<T> p) => p;
     Outer<T>.Inner<string> Method_T_String(Outer<T>.Inner<string> p) => p;
     Outer<T>.Inner<T> Method_T_T(Outer<T>.Inner<T> p) => p;
     
     object Cast(object o) => (Outer<T>.Inner<T>) o;
-    object TypeOf() => typeof(Outer<T>.Inner<T>);
+    //TODO: Revert when the other scenarios are fixed. AOT it crashes the tests.
+    //object TypeOf() => typeof(Outer<T>.Inner<T>);
      
     void Instantiate_Int_String() { Method_Int_String(new Outer<int>.Inner<string>()); }    
     void Instantiate_T_T() { Method_T_T(new Outer<T>.Inner<T>()); }
+*/
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -13,24 +13,20 @@ class Test<T>
     
     // Test subject for properties
     Outer<int>.Inner<string> Prop_Int_String { get; set; }
-/*
     Outer<int>.Inner<T> Prop_Int_T { get; set; }
     Outer<T>.Inner<string> Prop_T_String { get; set; }
-    Outer<T>.Inner<T> Prop_T_T { get; set; }
-    
-*/    
+    Outer<T>.Inner<T> Prop_T_T { get; set; }    
+
     // Test subject for methods
     Outer<int>.Inner<string> Method_Int_String(Outer<int>.Inner<string> p) => p;
-/*    
     Outer<int>.Inner<T> Method_Int_T(Outer<int>.Inner<T> p) => p;
     Outer<T>.Inner<string> Method_T_String(Outer<T>.Inner<string> p) => p;
     Outer<T>.Inner<T> Method_T_T(Outer<T>.Inner<T> p) => p;
     
-    object Cast(object o) => (Outer<T>.Inner<T>) o;
-    //TODO: Revert when the other scenarios are fixed. AOT it crashes the tests.
+    //TODO: Enable when other scenarios are fixed. AOT it crashes the tests.
+    //object Cast(object o) => (Outer<T>.Inner<T>) o;
     //object TypeOf() => typeof(Outer<T>.Inner<T>);
-     
+
     void Instantiate_Int_String() { Method_Int_String(new Outer<int>.Inner<string>()); }    
     void Instantiate_T_T() { Method_T_T(new Outer<T>.Inner<T>()); }
-*/
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericOuterSingleGenericInner.cs.txt
@@ -23,9 +23,8 @@ class Test<T>
     Outer<T>.Inner<string> Method_T_String(Outer<T>.Inner<string> p) => p;
     Outer<T>.Inner<T> Method_T_T(Outer<T>.Inner<T> p) => p;
     
-    //TODO: Enable when other scenarios are fixed. AOT it crashes the tests.
     object Cast(object o) => (Outer<T>.Inner<T>) o;
-    //object TypeOf() => typeof(Outer<T>.Inner<T>);
+    object TypeOf() => typeof(Outer<T>.Inner<T>);
 
     void Instantiate_Int_String() { Method_Int_String(new Outer<int>.Inner<string>()); }    
     void Instantiate_T_T() { Method_T_T(new Outer<T>.Inner<T>()); }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypeInstantiation.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypeInstantiation.cs.txt
@@ -12,8 +12,9 @@ public struct GenericStruct<T>
 class GenericTypeInstantiation
 {
     object ParameterlessClassCtor() => new GenericClass<int>();
+#if! API_DRIVER_SYSTEM_REFLECTION_METADATA
     object ClassCtorWithParameters() => new GenericClass<int>(42);
-    
     object StructCtorWithParameters() => new GenericStruct<int>(42);
-    //object ParameterlessStructCtor() => new GenericStruct<int>();
+    object ParameterlessStructCtor() => new GenericStruct<int>();
+#endif    
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypeInstantiation.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypeInstantiation.cs.txt
@@ -12,9 +12,7 @@ public struct GenericStruct<T>
 class GenericTypeInstantiation
 {
     object ParameterlessClassCtor() => new GenericClass<int>();
-#if! API_DRIVER_SYSTEM_REFLECTION_METADATA
     object ClassCtorWithParameters() => new GenericClass<int>(42);
     object StructCtorWithParameters() => new GenericStruct<int>(42);
     object ParameterlessStructCtor() => new GenericStruct<int>();
-#endif    
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
@@ -2,13 +2,14 @@ using System.Collections.Generic;
 
 class GenericTypesAsMembers
 {
+#if API_DRIVER_MONO_CECIL
     public IList<int> asField;
     public IList<int> Property { get { return asField; } set { asField = value; } }
+    private IDictionary<int, string> typeWithMultipleTypeParameters;
+#endif
     
     public IList<string> Method(IList<string> l)
     {
         return l;
-    }
-    
-    private IDictionary<int, string> typeWithMultipleTypeParameters;
+    }    
 }

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
@@ -4,9 +4,8 @@ class GenericTypesAsMembers
 {
     public IList<int> asField;
     private IDictionary<int, string> typeWithMultipleTypeParameters;
-#if API_DRIVER_MONO_CECIL
+
     public IList<int> Property { get { return asField; } set { asField = value; } }
-#endif
     
     public IList<string> Method(IList<string> l)
     {

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesAsMembers.cs.txt
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 
 class GenericTypesAsMembers
 {
-#if API_DRIVER_MONO_CECIL
     public IList<int> asField;
-    public IList<int> Property { get { return asField; } set { asField = value; } }
     private IDictionary<int, string> typeWithMultipleTypeParameters;
+#if API_DRIVER_MONO_CECIL
+    public IList<int> Property { get { return asField; } set { asField = value; } }
 #endif
     
     public IList<string> Method(IList<string> l)

--- a/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesInheritance.cs.txt
+++ b/Cecilifier.Core.Tests/TestResources/Integration/Generics/GenericTypesInheritance.cs.txt
@@ -4,9 +4,9 @@ class G<T>
 {
 }
 
-/*class GenericTypeInheritFromTypeInDifferentAssembly<T> : List<T>
+class GenericTypeInheritFromTypeInDifferentAssembly<T> : List<T>
 {
-}*/
+}
 
 class TypeInheritFromTypeInDifferentAssembly : List<int>
 {

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -9,7 +9,12 @@ namespace Cecilifier.Core.Tests.Integration
 {
     [TestFixture(typeof(MonoCecilContext))]
     [TestFixture(typeof(SystemReflectionMetadataContext))]
-    [EnableForContext<SystemReflectionMetadataContext>(nameof(TestGenericOuterAndInnerPermutations), nameof(TestSimplestGenericTypeDefinition), nameof(TestGenericTypesInheritance), nameof(TestGenericTypesAsMembers), IgnoreReason = "Not implemented")]
+    [EnableForContext<SystemReflectionMetadataContext>(
+        nameof(TestGenericOuterAndInnerPermutations), 
+        nameof(TestSimplestGenericTypeDefinition), 
+        nameof(TestGenericTypesInheritance), 
+        nameof(TestGenericTypesAsMembers),
+        nameof(TestGenericTypeInstantiation), IgnoreReason = "Not implemented")]
     public class GenericsTestCase<TResource> : ResourceTestBase<TResource> where TResource : IVisitorContext
     {
         [TestCase("GenericOuterNonGenericInner")]

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -9,7 +9,7 @@ namespace Cecilifier.Core.Tests.Integration
 {
     [TestFixture(typeof(MonoCecilContext))]
     [TestFixture(typeof(SystemReflectionMetadataContext))]
-    [EnableForContext<SystemReflectionMetadataContext>(nameof(TestGenericOuterAndInnerPermutations), nameof(TestSimplestGenericTypeDefinition), nameof(TestGenericTypesInheritance), IgnoreReason = "Not implemented")]
+    [EnableForContext<SystemReflectionMetadataContext>(nameof(TestGenericOuterAndInnerPermutations), nameof(TestSimplestGenericTypeDefinition), nameof(TestGenericTypesInheritance), nameof(TestGenericTypesAsMembers), IgnoreReason = "Not implemented")]
     public class GenericsTestCase<TResource> : ResourceTestBase<TResource> where TResource : IVisitorContext
     {
         [TestCase("GenericOuterNonGenericInner")]
@@ -57,7 +57,7 @@ namespace Cecilifier.Core.Tests.Integration
         [Test]
         public void TestGenericTypesAsMembers()
         {
-            AssertResourceTest(@"Generics/GenericTypesAsMembers");
+            AssertResourceTest("Generics/GenericTypesAsMembers");
         }
 
         [Test]

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -15,7 +15,7 @@ namespace Cecilifier.Core.Tests.Integration
         [TestCase("GenericOuterNonGenericInner")]
         [TestCase("GenericOuterSingleGenericInner")]
         [TestCase("GenericOuterDeepGenericInner")]
-        [ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericOuterNonGenericInner", "GenericOuterSingleGenericInner", "GenericOuterDeepGenericInner")]
+        //[ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericOuterNonGenericInner", "GenericOuterSingleGenericInner", "GenericOuterDeepGenericInner")]
         public void TestGenericOuterAndInnerPermutations(string testName)
         {
             AssertResourceTest(new CecilifyTestOptions

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -15,7 +15,7 @@ namespace Cecilifier.Core.Tests.Integration
         [TestCase("GenericOuterNonGenericInner")]
         [TestCase("GenericOuterSingleGenericInner")]
         [TestCase("GenericOuterDeepGenericInner")]
-        [ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericOuterNonGenericInner", "GenericOuterDeepGenericInner")]
+        [ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericOuterNonGenericInner", "GenericOuterSingleGenericInner", "GenericOuterDeepGenericInner")]
         public void TestGenericOuterAndInnerPermutations(string testName)
         {
             AssertResourceTest(new CecilifyTestOptions

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -12,9 +12,10 @@ namespace Cecilifier.Core.Tests.Integration
     [EnableForContext<SystemReflectionMetadataContext>(
         nameof(TestGenericOuterAndInnerPermutations), 
         nameof(TestSimplestGenericTypeDefinition), 
-        nameof(TestGenericTypesInheritance), 
         nameof(TestGenericTypesAsMembers),
-        nameof(TestGenericTypeInstantiation), IgnoreReason = "Not implemented")]
+        nameof(TestGenericTypeInstantiation),
+        nameof(TestGenericTypesInheritance), 
+        IgnoreReason = "Not implemented")]
     public class GenericsTestCase<TResource> : ResourceTestBase<TResource> where TResource : IVisitorContext
     {
         [TestCase("GenericOuterNonGenericInner")]
@@ -81,7 +82,7 @@ namespace Cecilifier.Core.Tests.Integration
         [Test]
         public void TestGenericTypeDefinitionWithMembers()
         {
-            AssertResourceTest(@"Generics/GenericTypeDefinitionWithMembers");
+            AssertResourceTest("Generics/GenericTypeDefinitionWithMembers");
         }
 
         [TestCase("GenericTypesInheritance", TestName = "GenericTypesInheritance")]
@@ -126,7 +127,7 @@ namespace Cecilifier.Core.Tests.Integration
         [Test]
         public void TestInnerTypeFromExternalAssembly()
         {
-            AssertResourceTestBinary(@"Generics/InnerTypeFromExternalAssembly");
+            AssertResourceTestBinary("Generics/InnerTypeFromExternalAssembly");
         }
         
         [Test]

--- a/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
+++ b/Cecilifier.Core.Tests/Tests/Integration/GenericsTestCase.cs
@@ -15,7 +15,6 @@ namespace Cecilifier.Core.Tests.Integration
         [TestCase("GenericOuterNonGenericInner")]
         [TestCase("GenericOuterSingleGenericInner")]
         [TestCase("GenericOuterDeepGenericInner")]
-        //[ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericOuterNonGenericInner", "GenericOuterSingleGenericInner", "GenericOuterDeepGenericInner")]
         public void TestGenericOuterAndInnerPermutations(string testName)
         {
             AssertResourceTest(new CecilifyTestOptions
@@ -83,7 +82,6 @@ namespace Cecilifier.Core.Tests.Integration
         [TestCase("GenericTypesInheritance", TestName = "GenericTypesInheritance")]
         [TestCase("SimpleGenericTypeInheritance", TestName = "SimpleGenericTypeInheritance")]
         [TestCase("ComplexGenericTypeInheritance", TestName = "ComplexGenericTypeInheritance")]
-        [ParameterizedResourceFilter<SystemReflectionMetadataContext>("GenericTypesInheritance", "SimpleGenericTypeInheritance", "ComplexGenericTypeInheritance")]
         public void TestGenericTypesInheritance(string testScenario)
         {
             AssertResourceTest($"Generics/{testScenario}");

--- a/Cecilifier.Core/AST/ExpressionVisitor.cs
+++ b/Cecilifier.Core/AST/ExpressionVisitor.cs
@@ -844,7 +844,7 @@ namespace Cecilifier.Core.AST
 
             AddCilInstruction(ilVar, OpCodes.Ldtoken, Context.GetTypeInfo(node.Type).Type);
             string operand = getTypeFromHandleSymbol.MethodResolverExpression(Context);
-            Context.ApiDriver.WriteCilInstruction(Context, ilVar, OpCodes.Call, operand);
+            Context.ApiDriver.WriteCilInstruction(Context, ilVar, OpCodes.Call, new CilToken(operand));
         }
 
         public override void VisitRangeExpression(RangeExpressionSyntax node)

--- a/Cecilifier.Core/AST/IVisitorContext.cs
+++ b/Cecilifier.Core/AST/IVisitorContext.cs
@@ -18,6 +18,7 @@ public interface IVisitorContext
 {
     static virtual IVisitorContext CreateContext(CecilifierOptions options, SemanticModel semanticModel) => throw new NotImplementedException();
     static virtual string[] BclAssembliesForCompilation() => throw new NotImplementedException();
+    static virtual string[] GetPreprocessorSymbols() => throw new NotImplementedException();
 
     IApiDriverDefinitionsFactory ApiDefinitionsFactory { get; }
     public IILGeneratorApiDriver ApiDriver { get; }

--- a/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
+++ b/Cecilifier.Core/AST/PropertyDeclarationVisitor.cs
@@ -129,7 +129,8 @@ namespace Cecilifier.Core.AST
             var propertyGenerationData = new PropertyGenerationData(
                                     propertySymbol.ContainingType.ToDisplayString(),
                                     propertyDeclaringTypeVar,
-                                    propertySymbol.ContainingSymbol is INamedTypeSymbol { IsGenericType: true} && propertySymbol.IsDefinedInCurrentAssembly(Context),
+                                    // is INamedTypeSymbol { IsGenericType: true} && propertySymbol.IsDefinedInCurrentAssembly(Context)
+                                    (INamedTypeSymbol) propertySymbol.ContainingSymbol,
                                     propDefVar,
                                     propertyName,
                                     AccessorsModifiersFor(node, propertySymbol),

--- a/Cecilifier.Core/ApiDriver/DefinitionsFactory/IApiDriverDefinitionsFactory.cs
+++ b/Cecilifier.Core/ApiDriver/DefinitionsFactory/IApiDriverDefinitionsFactory.cs
@@ -63,6 +63,8 @@ public interface IApiDriverDefinitionsFactory
     public IEnumerable<string> Constructor(IVisitorContext context, BodiedMemberDefinitionContext definitionContext, string typeName, bool isStatic, string methodAccessibility, string[] paramTypes, string? methodDefinitionPropertyValues = null);
     public IEnumerable<string> Field(IVisitorContext context, in MemberDefinitionContext definitionContext, ISymbol fieldOrEvent, ITypeSymbol fieldType, string fieldAttributes, bool isVolatile, bool isByRef, in FieldInitializationData initializer = default);
     public IEnumerable<string> Field(IVisitorContext context, MemberDefinitionContext definitionContext, string declaringTypeName, ResolvedType fieldType, string fieldAttributes, bool isVolatile, bool isByRef, FieldInitializationData initializer = default);
+    public IEnumerable<string> FieldReference(IVisitorContext context, string fieldReferenceVariable, string fieldName, ResolvedType fieldType, in ResolvedType declaringType);
+    
     IEnumerable<string> MethodBody(IVisitorContext context, string methodName, IlContext ilContext, ResolvedType[] localVariableTypes, InstructionRepresentation[] instructions);
     DefinitionVariable LocalVariable(IVisitorContext context, string variableName, string methodDefinitionVariableName, ResolvedType resolvedType);
     IEnumerable<string> Property(IVisitorContext context, BodiedMemberDefinitionContext definitionContext, string declaringTypeName, List<ParameterSpec> propertyParameters, ResolvedType propertyType);

--- a/Cecilifier.Core/Cecilifier.cs
+++ b/Cecilifier.Core/Cecilifier.cs
@@ -20,7 +20,7 @@ namespace Cecilifier.Core
             UsageVisitor.ResetInstance();
             
             using var stream = new StreamReader(content);
-            var syntaxTree = CSharpSyntaxTree.ParseText(stream.ReadToEnd(), new CSharpParseOptions(CurrentLanguageVersion));
+            var syntaxTree = CSharpSyntaxTree.ParseText(stream.ReadToEnd(), new CSharpParseOptions(CurrentLanguageVersion, preprocessorSymbols: options.PreprocessorSymbols));
             var metadataReferences = options.References.Select(refPath => MetadataReference.CreateFromFile(refPath)).ToArray();
 
             var comp = CSharpCompilation.Create(

--- a/Cecilifier.Core/CecilifierOptions.cs
+++ b/Cecilifier.Core/CecilifierOptions.cs
@@ -9,4 +9,5 @@ public record CecilifierOptions
     public INameStrategy Naming { get; init; } = new DefaultNameStrategy();
 
     public IReadOnlyList<string> References { get; init; }
+    public IReadOnlyList<string> PreprocessorSymbols { get; init; }
 }

--- a/Cecilifier.Core/CodeGeneration/PrimaryConstructor.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/PrimaryConstructor.Generator.cs
@@ -58,7 +58,7 @@ public class PrimaryConstructorGenerator
         var propertyData = new PropertyGenerationData(
                                     declaringType.OriginalDefinition.ToDisplayString(),
                                     declaringTypeVariable.VariableName,
-                                    declaringType.TypeParameters.Length > 0,
+                                    declaringType,
                                     propDefVar,
                                     parameter.Identifier.Text,
                                     new Dictionary<string, string>

--- a/Cecilifier.Core/CodeGeneration/Property.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/Property.Generator.cs
@@ -16,7 +16,7 @@ namespace Cecilifier.Core.CodeGeneration;
 internal record struct PropertyGenerationData(
     string DeclaringTypeNameForRegistration,
     string DeclaringTypeVariable,
-    bool DeclaringTypeIsGeneric,
+    INamedTypeSymbol DeclaringTypeSymbol,
     string Variable, 
     string Name, 
     IDictionary<string, string> AccessorModifiers,
@@ -83,7 +83,7 @@ internal class PropertyGenerator
         if (!property.IsStatic)
             Context.ApiDriver.WriteCilInstruction(Context, ilContext, OpCodes.Ldarg_1);
 
-        var operand = property.DeclaringTypeIsGeneric ? MakeGenericInstanceType(in property) : _backingFieldVar;
+        var operand = property.DeclaringTypeSymbol is { IsGenericType: true } ? BackingFieldReferenceOnGenericInstanceType(in property) : _backingFieldVar;
         Context.ApiDriver.WriteCilInstruction(Context, ilContext, property.StoreOpCode, operand.AsToken());
         Context.AddCompilerGeneratedAttributeTo(ilContext.AssociatedMethodVariable, VariableMemberKind.Method);
     }
@@ -126,7 +126,7 @@ internal class PropertyGenerator
             Context.ApiDriver.WriteCilInstruction(Context, ilVar, OpCodes.Ldarg_0);
         
         Debug.Assert(_backingFieldVar != null);
-        var operand = propertyGenerationData.DeclaringTypeIsGeneric ? MakeGenericInstanceType(in propertyGenerationData) : _backingFieldVar;
+        var operand = propertyGenerationData.DeclaringTypeSymbol is { IsGenericType: true } ? BackingFieldReferenceOnGenericInstanceType(in propertyGenerationData) : _backingFieldVar;
         Context.ApiDriver.WriteCilInstruction(Context, ilVar, propertyGenerationData.LoadOpCode, operand.AsToken());
         Context.ApiDriver.WriteCilInstruction(Context, ilVar, OpCodes.Ret);
         
@@ -157,16 +157,13 @@ internal class PropertyGenerator
         Context.AddCompilerGeneratedAttributeTo(_backingFieldVar, VariableMemberKind.Field);
     }
     
-    private string MakeGenericInstanceType(ref readonly PropertyGenerationData property)
+    private string BackingFieldReferenceOnGenericInstanceType(ref readonly PropertyGenerationData property)
     {
-        var genTypeVar = Context.Naming.SyntheticVariable(property.Name, ElementKind.GenericInstance);
-        var fieldRefVar = Context.Naming.MemberReference("fld_");
+        var closedDeclaringType = Context.TypeResolver.MakeGenericInstanceType(property.DeclaringTypeVariable, property.DeclaringTypeSymbol, new TypeResolutionContext(ResolveTargetKind.TypeReference, property.DeclaringTypeSymbol.IsValueType ? TypeResolutionOptions.IsValueType : TypeResolutionOptions.None ));
         
-        Context.Generate(
-            [
-                $"var {genTypeVar} = {property.DeclaringTypeVariable}.MakeGenericInstanceType({property.DeclaringTypeVariable}.GenericParameters.ToArray());",
-                $"var {fieldRefVar} = new FieldReference({_backingFieldVar}.Name, {_backingFieldVar}.FieldType, {genTypeVar});"
-            ]);
+        var fieldRefVar = Context.Naming.MemberReference($"backingField_{property.Name}");
+        var exps = Context.ApiDefinitionsFactory.FieldReference(Context, fieldRefVar, Utils.BackingFieldNameForAutoProperty(property.Name), property.Type(ResolveTargetKind.Field), in closedDeclaringType);
+        Context.Generate(exps);
         return fieldRefVar;
     }
 }

--- a/Cecilifier.Core/CodeGeneration/Record.Generator.cs
+++ b/Cecilifier.Core/CodeGeneration/Record.Generator.cs
@@ -729,7 +729,7 @@ internal partial class RecordGenerator
         PropertyGenerationData propertyData = new(
             _recordSymbol.OriginalDefinition.ToDisplayString(),
             recordTypeDefinitionVariable,
-            record.TypeParameterList?.Parameters.Count > 0,
+            _recordSymbol,
             equalityContractPropertyVar,
             propertyName,
             new Dictionary<string, string> { ["get"] = "MethodAttributes.Family | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.NewSlot | MethodAttributes.Virtual" },

--- a/Cecilifier.Core/TypeSystem/ITypeResolver.cs
+++ b/Cecilifier.Core/TypeSystem/ITypeResolver.cs
@@ -23,6 +23,8 @@ public interface ITypeResolver
     ResolvedType ApplySpecificSyntax(string variableName, in TypeResolutionContext resolutionContext);
     
     ResolvedType MakeArrayType(ITypeSymbol elementType, in TypeResolutionContext resolutionContext);
+    
+    ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext);
 
     Bcl Bcl { get; }
 }

--- a/Cecilifier.Core/TypeSystem/TypeResolverBase.cs
+++ b/Cecilifier.Core/TypeSystem/TypeResolverBase.cs
@@ -121,6 +121,7 @@ namespace Cecilifier.Core.TypeSystem
                 || type.SpecialType == SpecialType.System_Delegate
                 || type.SpecialType == SpecialType.System_MulticastDelegate
                 || type.SpecialType == SpecialType.System_AsyncCallback
+                || type.SpecialType == SpecialType.System_RuntimeTypeHandle
                 || type.TypeKind == TypeKind.Interface)
             {
                 return null;

--- a/Cecilifier.Core/TypeSystem/TypeResolverBase.cs
+++ b/Cecilifier.Core/TypeSystem/TypeResolverBase.cs
@@ -182,6 +182,6 @@ namespace Cecilifier.Core.TypeSystem
             return typeArguments.Slice(0, count);
         }
 
-        protected abstract ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext);
+        public abstract ResolvedType MakeGenericInstanceType(ResolvedType typeReference, INamedTypeSymbol genericTypeSymbol, in TypeResolutionContext resolutionContext);
     }
 }

--- a/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
+++ b/Cecilifier.TypeMapGenerator/Cecilifier.TypeMapGenerator.csproj
@@ -17,7 +17,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-3.final" PrivateAssets="all" />
-        <PackageReference Include="System.Reflection.Metadata" Version="9.0.0" PrivateAssets="all" />
+        <PackageReference Include="System.Reflection.Metadata" Version="9.0.11" PrivateAssets="all" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Cecilifier.TypeMapGenerator/TypeToAssemblyMappingSourceGenerator.cs
+++ b/Cecilifier.TypeMapGenerator/TypeToAssemblyMappingSourceGenerator.cs
@@ -13,13 +13,13 @@ namespace Cecilifier.TypeMapGenerator;
 #pragma warning disable RS1035
 
 [Generator]
-public class SampleIncrementalSourceGenerator : ISourceGenerator
+public class SampleIncrementalSourceGenerator : IIncrementalGenerator
 {
-    public void Initialize(GeneratorInitializationContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterForPostInitialization(c =>
+        context.RegisterSourceOutput(context.CompilationProvider, (spc, compilation) => 
         {
-            c.AddSource(
+            spc.AddSource(
                 "TypeToAssemblyNameReferenceMap.gen.cs",
                 $$"""
                 // Generated on {{DateTime.Now}}
@@ -93,8 +93,8 @@ public class SampleIncrementalSourceGenerator : ISourceGenerator
         var assemblyName = metadataReader.GetAssemblyDefinition().GetAssemblyName();
         string assemblyNameReference;
         
-        assemblyReferences.Append($"""var ar{index} = AssemblyNameReference.Parse("{ assemblyName.FullName }");{Environment.NewLine}""");
-        assemblyNameReferenceCache[assemblyName.FullName.GetHashCode()] = assemblyNameReference = $"ar{index}";
+        assemblyReferences.Append($"""var {IdentifierFor(assemblyName)} = AssemblyNameReference.Parse("{ assemblyName.FullName }");{Environment.NewLine}""");
+        assemblyNameReferenceCache[assemblyName.FullName.GetHashCode()] = assemblyNameReference = IdentifierFor(assemblyName);
 
         foreach(var td in metadataReader.TypeDefinitions.Select(th => metadataReader.GetTypeDefinition(th)).Where(IsPublic))
         {
@@ -114,8 +114,8 @@ public class SampleIncrementalSourceGenerator : ISourceGenerator
             if (!assemblyNameReferenceCache.TryGetValue(assemblyName.FullName.GetHashCode(), out assemblyNameReference))
             {
                 index++;
-                assemblyReferences.Append($"""var ar{index} = AssemblyNameReference.Parse("{ assemblyName.FullName }");{Environment.NewLine}""");
-                assemblyNameReferenceCache[assemblyName.FullName.GetHashCode()] = assemblyNameReference = $"ar{index}";
+                assemblyReferences.Append($"""var {IdentifierFor(assemblyName)} = AssemblyNameReference.Parse("{ assemblyName.FullName }");{Environment.NewLine}""");
+                assemblyNameReferenceCache[assemblyName.FullName.GetHashCode()] = assemblyNameReference = IdentifierFor(assemblyName);
             }
 
             // TODO: Do we need to use FullNameFor() ?
@@ -126,6 +126,11 @@ public class SampleIncrementalSourceGenerator : ISourceGenerator
         return assemblyReferences.ToString();
 
         static bool IsPublic(TypeDefinition typeDefinition) => (typeDefinition.Attributes & TypeAttributes.VisibilityMask) != TypeAttributes.NotPublic;
+    }
+
+    private string IdentifierFor(AssemblyName assemblyName)
+    {
+        return assemblyName.Name.Replace('.', '_');
     }
 
     private static string FullNameFor(MetadataReader metadataReader, TypeDefinition td)

--- a/Cecilifier.Web/Cecilifier.Web.csproj
+++ b/Cecilifier.Web/Cecilifier.Web.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multiple improvements on supporting `generic types` for System.Reflection.Metadata api driver.

a5674d9d fix: fixes a bunch of generict type instantiation issues in System.Reflection.Metadata Api driver (#363)
d8d10da0 refact: minor code cleanup
11d0c8dd test: enables GenericTypeInstantiation test for System.Reflection.Metadata (#363)
a061bef0 fix: fixes last generic type in members failing test (#363)
c9d473f9 refact: better type parameter name (#363)
5577ddc9 feat: support for generic types as field types (#363)
3c16f7bc feat: initial support for generic types in members (#363)
ca7d55a0 feat: added support for API Drivers to define custom preprocessor symbols
5b87555f test: reenable test (#363)
b9152e7e test: remove unecessary attribute from tests (#363)
945b3066 fix: handling of 'typeof' operator for generic types in System.Reflection.Metadata API driver  (#363)
cc6c2aa7 fix: type resolution when a token is required in an IL instruction (#363)
b9a81941 test: improve test reliability by avoid incorrect cache hit when previous test runs left 0 sized files on disk
33b2a427 updates Microsoft.NET.Test.Sdk version to 18.5.1
fb69c898 update roslyn to 5.3.0
ebddcddd test: reenable tests that were failing due to incorrect type reference comparison fixed in previous commit (#363)
6dd7fd21 fix: improve type reference comparison when comparing assemblies in tests (#363)
0ac02173 feat: update type resolution logic to correctly resolve closed generic types used as property / method return type (#363)
33cb4639 feat: enables 'TestGenericOuterAndInnerPermutations' covering fields (#363)
5f8a0e40 refact: clean up code
7c211fd5 bumps nuget package versions
bb7b1b2f bumps version to 2.27.0
